### PR TITLE
Pin container build actions to commit SHAs and base images to digests

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -17,14 +17,14 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/schwab-mcp
           tags: |
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build image (PR)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: Containerfile
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build and push
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: Containerfile

--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.23
 
-FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS uv-tools
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim@sha256:f5b1b14b0100eb85b07650b33d702a65c2a826bc301ddbdc89f43da6d23b3ab1 AS uv-tools
 
-FROM python:3.14-slim AS builder
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN uv build --wheel --out-dir /dist && \
         --no-emit-project \
         --output-file /dist/requirements.txt
 
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard"
+    ":dependencyDashboard",
+    "helpers:pinGitHubActionDigests",
+    "docker:pinDigests"
   ],
   "labels": ["dependencies"],
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
## What this does, in one sentence

Locks the container build pipeline to immutable references — GitHub Actions to commit SHAs, base images to manifest digests — and configures Renovate to keep those pins up to date.

## Why

Tags (`@v6`, `python:3.14-slim`) are mutable. If an upstream maintainer is compromised, they can repoint a tag and our very next build runs the attacker's code with `packages: write`. The `tj-actions/changed-files` incident (CVE-2025-30066) proved this happens to popular actions, not just obscure ones. Commit SHAs and `@sha256:` digests are content-addressed and cannot be repointed.

`agent.yaml` already SHA-pins its actions; `container.yml` now matches.

## What changed

| Change | File | Why |
|---|---|---|
| 5 actions: `@vN` → `@<sha>  # vX.Y.Z` | `.github/workflows/container.yml` | Immutable refs for the workflow that publishes the image |
| 3 `FROM` lines: add `@sha256:<digest>` | `Containerfile` | Reproducible builds; upstream re-tags no longer flow in silently |
| Add `helpers:pinGitHubActionDigests`, `docker:pinDigests` presets | `renovate.json` | Renovate proposes reviewable PRs to bump pins instead of letting them go stale |

## Resolved pins

### Actions (`container.yml`)

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `docker/setup-buildx-action` | `4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` | v4.0.0 |
| `docker/login-action` | `4907a6ddec9925e35a0a9e82d7399ccc52663121` | v4.1.0 |
| `docker/metadata-action` | `030e881283bb7a6894de51c315a6bfe6a94e05cf` | v6.0.0 |
| `docker/build-push-action` | `bcafcacb16a39f128d818304e6c9c0c18556b85f` | v7.1.0 |

`actions/checkout` reuses the SHA already pinned in `agent.yaml` for consistency. The `docker/*` SHAs are the commits each major-version tag currently points at, resolved via the GitHub API.

### Base images (`Containerfile`)

| Image | Digest |
|---|---|
| `ghcr.io/astral-sh/uv:python3.12-trixie-slim` | `sha256:f5b1b14b0100eb85b07650b33d702a65c2a826bc301ddbdc89f43da6d23b3ab1` |
| `python:3.14-slim` | `sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033` |

Digests resolved via the registry HTTP API (`Docker-Content-Digest` header on the manifest endpoint), so they're the multi-arch index digests — `linux/amd64` and `linux/arm64` builds both resolve from them.

## How I know it works

- `container.yml` parses as valid YAML.
- `renovate.json` parses as valid JSON.
- No Python touched, so no test/lint changes expected.
- Each action SHA was resolved against the live GitHub API (`repos/<owner>/<repo>/commits/<tag>`), and each digest against the live registry, on 2026-05-01.

Closes #8
Closes #9
