### PR TITLE
fix(cli): hide secret prompts and steer users off argv for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,31 +32,33 @@ pip install git+https://github.com/jkoelker/schwab-mcp.git
 
 ### Authentication
 
-Before running the server, you must authenticate with Schwab to generate a token file.
+First, store your Schwab credentials locally. You'll be prompted for the
+client secret (and optional Discord bot token) without echoing them to the
+terminal:
 
 ```bash
-# If installed via uv tool
-schwab-mcp auth --client-id YOUR_KEY --client-secret YOUR_SECRET --callback-url https://127.0.0.1:8182
-
-# If running from source
-uv run schwab-mcp auth --client-id YOUR_KEY --client-secret YOUR_SECRET --callback-url https://127.0.0.1:8182
+schwab-mcp save-credentials   # prompts for Client ID, Client Secret (hidden), Discord token (hidden, optional)
 ```
 
-This will open a browser window for you to log in to Schwab. Once complete, a token will be saved to `~/.local/share/schwab-mcp/token.yaml`.
+Then run the OAuth flow to generate a token file:
+
+```bash
+schwab-mcp auth
+```
+
+This will open a browser window for you to log in to Schwab. Once complete,
+a token will be saved to `~/.local/share/schwab-mcp/token.yaml`.
 
 ### Running the Server
 
 Start the MCP server to expose the tools to your MCP client.
 
 ```bash
-# Basic Read-Only Mode (Safest)
-schwab-mcp server --client-id YOUR_KEY --client-secret YOUR_SECRET
+# Basic Read-Only Mode (Safest) — credentials read from save-credentials file
+schwab-mcp server
 
 # With Trading Enabled (Requires Discord Approval)
 schwab-mcp server \
-  --client-id YOUR_KEY \
-  --client-secret YOUR_SECRET \
-  --discord-token BOT_TOKEN \
   --discord-channel-id CHANNEL_ID \
   --discord-approver YOUR_USER_ID
 ```
@@ -67,11 +69,17 @@ schwab-mcp server \
 
 You can configure the server using CLI flags or Environment Variables.
 
+> **Avoid passing `--client-secret` or `--discord-token` on the command
+> line** — command-line arguments are visible to other processes on your
+> machine via `ps`. Prefer `schwab-mcp save-credentials` or the
+> environment variables below.
+
 | Flag | Env Variable | Description |
 |------|--------------|-------------|
 | `--client-id` | `SCHWAB_CLIENT_ID` | **Required**. Schwab App Key. |
 | `--client-secret` | `SCHWAB_CLIENT_SECRET` | **Required**. Schwab App Secret. |
 | `--callback-url` | `SCHWAB_CALLBACK_URL` | Redirect URL (default: `https://127.0.0.1:8182`). |
+| `--discord-token` | `SCHWAB_MCP_DISCORD_TOKEN` | Discord bot token for trade approvals. |
 | `--token-path` | N/A | Path to save/load token (default: `~/.local/share/...`). |
 | `--jesus-take-the-wheel`| N/A | **DANGER**. Bypasses Discord approval for trades. |
 | `--no-technical-tools` | N/A | Disables technical analysis tools (SMA, RSI, etc.). |

--- a/src/schwab_mcp/cli.py
+++ b/src/schwab_mcp/cli.py
@@ -203,6 +203,7 @@ def server(
     creds = tokens.load_credentials(tokens.credentials_path(APP_NAME))
     client_id = client_id or creds.get("client_id")
     client_secret = client_secret or creds.get("client_secret")
+    discord_token = discord_token or creds.get("discord_token")
     if not client_id or not client_secret:
         send_error_response(
             "client-id and client-secret are required. "
@@ -346,12 +347,22 @@ def server(
     "--client-secret",
     type=str,
     prompt="Schwab Client Secret",
+    hide_input=True,
     help="Schwab Client Secret",
 )
-def save_credentials(client_id: str, client_secret: str) -> None:
+@click.option(
+    "--discord-token",
+    type=str,
+    prompt="Discord Bot Token (optional, press Enter to skip)",
+    hide_input=True,
+    default="",
+    show_default=False,
+    help="Discord bot token for the approval workflow (optional)",
+)
+def save_credentials(client_id: str, client_secret: str, discord_token: str) -> None:
     """Save Schwab client credentials to a local file."""
     path = tokens.credentials_path(APP_NAME)
-    tokens.save_credentials(path, client_id, client_secret)
+    tokens.save_credentials(path, client_id, client_secret, discord_token or None)
     click.echo(f"Credentials saved to: {path}")
 
 

--- a/src/schwab_mcp/tokens.py
+++ b/src/schwab_mcp/tokens.py
@@ -150,7 +150,12 @@ def load_credentials(path: str) -> dict[str, str]:
     return data
 
 
-def save_credentials(path: str, client_id: str, client_secret: str) -> None:
+def save_credentials(
+    path: str,
+    client_id: str,
+    client_secret: str,
+    discord_token: str | None = None,
+) -> None:
     """Write client credentials to a YAML file with restricted permissions.
 
     The file is created with ``0o600`` permissions so that only the owning
@@ -160,13 +165,18 @@ def save_credentials(path: str, client_id: str, client_secret: str) -> None:
         path: Path to the credentials file
         client_id: Schwab client ID
         client_secret: Schwab client secret
+        discord_token: Optional Discord bot token for the approval workflow
     """
     pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+    data: dict[str, str] = {"client_id": client_id, "client_secret": client_secret}
+    if discord_token:
+        data["discord_token"] = discord_token
 
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as f:
         yaml.safe_dump(
-            {"client_id": client_id, "client_secret": client_secret},
+            data,
             f,
             default_flow_style=False,
             explicit_start=True,

--- a/tests/test_cli_credentials.py
+++ b/tests/test_cli_credentials.py
@@ -207,7 +207,7 @@ class TestSaveCredentialsCommand:
         result = runner.invoke(
             cli.cli,
             ["save-credentials"],
-            input="my-client-id\nmy-client-secret\n",
+            input="my-client-id\nmy-client-secret\n\n",
             catch_exceptions=False,
         )
 
@@ -220,6 +220,46 @@ class TestSaveCredentialsCommand:
         assert data == {
             "client_id": "my-client-id",
             "client_secret": "my-client-secret",
+        }
+
+    def test_secret_prompts_do_not_echo(self, monkeypatch, tmp_path):
+        creds_path = tmp_path / "credentials.yaml"
+        monkeypatch.setattr(cli.tokens, "credentials_path", lambda app: str(creds_path))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            ["save-credentials"],
+            input="visible-id\nhidden-secret\nhidden-discord-token\n",
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "visible-id" in result.output
+        assert "hidden-secret" not in result.output
+        assert "hidden-discord-token" not in result.output
+
+    def test_saves_discord_token_when_prompted(self, monkeypatch, tmp_path):
+        creds_path = tmp_path / "credentials.yaml"
+        monkeypatch.setattr(cli.tokens, "credentials_path", lambda app: str(creds_path))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            ["save-credentials"],
+            input="my-client-id\nmy-client-secret\nmy-discord-token\n",
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+
+        with open(creds_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data == {
+            "client_id": "my-client-id",
+            "client_secret": "my-client-secret",
+            "discord_token": "my-discord-token",
         }
 
     def test_saves_credentials_with_flags(self, monkeypatch, tmp_path):
@@ -235,6 +275,8 @@ class TestSaveCredentialsCommand:
                 "flag-id",
                 "--client-secret",
                 "flag-secret",
+                "--discord-token",
+                "",
             ],
             catch_exceptions=False,
         )
@@ -253,9 +295,93 @@ class TestSaveCredentialsCommand:
         runner = CliRunner()
         runner.invoke(
             cli.cli,
-            ["save-credentials", "--client-id", "id", "--client-secret", "secret"],
+            [
+                "save-credentials",
+                "--client-id",
+                "id",
+                "--client-secret",
+                "secret",
+                "--discord-token",
+                "",
+            ],
             catch_exceptions=False,
         )
 
         mode = os.stat(creds_path).st_mode & 0o777
         assert mode == 0o600
+
+
+class TestServerDiscordTokenCredentialsFile:
+    def _patch_server(self, monkeypatch, captured: dict[str, Any]) -> None:
+        monkeypatch.setattr(cli, "AsyncClient", FakeAsyncClient)
+        monkeypatch.setattr(
+            cli.tokens, "Manager", lambda p: type("M", (), {"path": p})()
+        )
+        monkeypatch.setattr(
+            cli.schwab_auth, "easy_client", lambda **kw: FakeAsyncClient()
+        )
+
+        class FakeDiscordSettings:
+            def __init__(self, **kwargs):
+                captured["discord_settings"] = kwargs
+
+        class FakeDiscordManager:
+            authorized_user_ids = staticmethod(
+                lambda ids: frozenset(ids) if ids else frozenset()
+            )
+
+            def __init__(self, settings):
+                captured["discord_manager_settings"] = settings
+
+        monkeypatch.setattr(cli, "DiscordApprovalSettings", FakeDiscordSettings)
+        monkeypatch.setattr(cli, "DiscordApprovalManager", FakeDiscordManager)
+        monkeypatch.setattr(
+            cli,
+            "SchwabMCPServer",
+            lambda *a, **kw: type("S", (), {"run": staticmethod(lambda: None)})(),
+        )
+        monkeypatch.setattr(cli.anyio, "run", lambda func, **kw: None)
+
+    def test_server_reads_discord_token_from_credentials_file(
+        self, monkeypatch, tmp_path
+    ):
+        captured: dict[str, Any] = {}
+        self._patch_server(monkeypatch, captured)
+
+        creds_path = tmp_path / "credentials.yaml"
+        with open(creds_path, "w") as f:
+            yaml.safe_dump(
+                {
+                    "client_id": "file-id",
+                    "client_secret": "file-secret",
+                    "discord_token": "file-discord-token",
+                },
+                f,
+            )
+
+        monkeypatch.setattr(cli.tokens, "credentials_path", lambda app: str(creds_path))
+        for var in (
+            "SCHWAB_CLIENT_ID",
+            "SCHWAB_CLIENT_SECRET",
+            "SCHWAB_MCP_DISCORD_TOKEN",
+            "SCHWAB_MCP_DISCORD_APPROVERS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            [
+                "server",
+                "--token-path",
+                str(tmp_path / "token.yaml"),
+                "--discord-channel-id",
+                "12345",
+                "--discord-approver",
+                "67890",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert captured["discord_settings"]["token"] == "file-discord-token"

--- a/tests/test_conftest_fixtures.py
+++ b/tests/test_conftest_fixtures.py
@@ -14,7 +14,6 @@ import asyncio
 from typing import Any
 
 
-
 class TestFakeCallFactory:
     """Tests for fake_call_factory fixture."""
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -419,3 +419,36 @@ class TestSaveCredentials:
             content = f.read()
 
         assert content.startswith("---")
+
+    def test_writes_discord_token_when_provided(self, tmp_path):
+        path = str(tmp_path / "credentials.yaml")
+
+        tokens.save_credentials(path, "my-id", "my-secret", discord_token="bot-token")
+
+        with open(path) as f:
+            data = yaml.safe_load(f)
+
+        assert data == {
+            "client_id": "my-id",
+            "client_secret": "my-secret",
+            "discord_token": "bot-token",
+        }
+
+    @pytest.mark.parametrize("discord_token", [None, ""])
+    def test_omits_discord_token_when_falsy(self, tmp_path, discord_token):
+        path = str(tmp_path / "credentials.yaml")
+
+        tokens.save_credentials(path, "my-id", "my-secret", discord_token=discord_token)
+
+        with open(path) as f:
+            data = yaml.safe_load(f)
+
+        assert data == {"client_id": "my-id", "client_secret": "my-secret"}
+
+    def test_discord_token_round_trips_through_load(self, tmp_path):
+        path = str(tmp_path / "credentials.yaml")
+
+        tokens.save_credentials(path, "my-id", "my-secret", discord_token="bot-token")
+        loaded = tokens.load_credentials(path)
+
+        assert loaded["discord_token"] == "bot-token"


### PR DESCRIPTION
**One sentence:** stop leaking the Schwab client secret and Discord bot token through terminal echo and the process list, and give them a safe place to live instead.

Closes #5

## What & why

| Change | Why |
|---|---|
| `hide_input=True` on the `--client-secret` prompt | The save-credentials prompt echoed the secret to the terminal — captured by scrollback, tmux/screen logs, and screen-shares. |
| New optional hidden `--discord-token` prompt on `save-credentials`, stored in `credentials.yaml` | There was no file-based storage for the Discord bot token, so users were forced onto argv or env. Now it lives in the same `0o600` file as the Schwab creds. |
| `server` command reads `discord_token` from `credentials.yaml` as a fallback | Mirrors the existing `client_id`/`client_secret` fallback so the file actually gets used. |
| README quick-start rewritten to lead with `save-credentials` + env vars; secret-bearing flags removed from examples | The old examples told users to put `--client-secret YOUR_SECRET --discord-token BOT_TOKEN` on the command line — visible to every local process via `ps` for the entire server lifetime. |
| README warning under Configuration | Spell out the `ps` exposure so users who do reach for the flags know the risk. |

## Where things changed

```
src/schwab_mcp/
  cli.py       — save-credentials: hide_input + discord-token prompt; server: discord_token fallback
  tokens.py    — save_credentials() takes optional discord_token, writes it when present
README.md      — Authentication + Running-the-Server sections rewritten; env-var table row; warning blockquote
tests/
  test_tokens.py            — 4 new tests: discord_token write/omit/round-trip
  test_cli_credentials.py   — prompt input updated (3 prompts now); 3 new tests: no-echo, discord prompt save,
                              server reads discord_token from credentials file
  test_conftest_fixtures.py — 1 blank line removed by ruff format (pre-existing, unrelated)
```

## How I know it works

- `ruff format` / `ruff check`: clean
- `pyright`: 0 errors, 0 warnings
- `pytest`: **308 passed** (was 301 on main; 7 net new)
- `test_secret_prompts_do_not_echo` asserts the client ID appears in CLI output but the secret and Discord token do **not** — proving `hide_input=True` is wired through.
- `test_server_reads_discord_token_from_credentials_file` asserts a `DiscordApprovalSettings` is constructed with the token loaded from `credentials.yaml` when no flag/env is set.
