### PR TITLE
fix(approvals): show full args in code block, redact account_hash, fail closed on overflow

### DIFF
--- a/docs/discord-setup.md
+++ b/docs/discord-setup.md
@@ -34,6 +34,12 @@ To use the account modification tools (placing orders, cancelling orders, etc.) 
 2.  Right-click the text channel where you want the bot to post.
 3.  Click **Copy Channel ID**. This is your `SCHWAB_MCP_DISCORD_CHANNEL_ID`.
 
+> **Make the approval channel private.** Approval requests include the trade
+> details (symbol, side, quantity, price). The `--discord-approver` allow-list
+> only controls whose ✅/❌ reactions count — it does **not** restrict who can
+> read the channel. Create a private channel that only the bot and your
+> approver user(s) can view.
+
 ## 5. Get Your User ID (Approver)
 
 1.  Right-click your own username in Discord.

--- a/src/schwab_mcp/approvals/discord.py
+++ b/src/schwab_mcp/approvals/discord.py
@@ -16,6 +16,10 @@ from schwab_mcp.approvals.base import (
 
 logger = logging.getLogger(__name__)
 
+# Discord embed field values are capped at 1024 chars; stay a little under so
+# the surrounding code-fence markers always fit.
+_ARGUMENTS_FIELD_LIMIT = 1000
+
 
 @dataclass(slots=True, frozen=True)
 class DiscordApprovalSettings:
@@ -104,7 +108,38 @@ class DiscordApprovalManager(ApprovalManager):
         await self.start()
         channel = await self._ensure_channel()
 
-        message = await channel.send(embed=self._build_pending_embed(request))
+        rendered_args = self._format_arguments(request.arguments)
+        if len(rendered_args) > _ARGUMENTS_FIELD_LIMIT:
+            logger.warning(
+                "Auto-denying approval %s for tool '%s': arguments too large "
+                "to display in full (%d chars)",
+                request.id,
+                request.tool_name,
+                len(rendered_args),
+            )
+            embed = discord.Embed(
+                title="Write operation auto-denied",
+                description=(
+                    f"Tool `{request.tool_name}` was denied automatically: its "
+                    f"arguments are too large to display in full "
+                    f"({len(rendered_args)} chars). Approving a partial view "
+                    "is unsafe."
+                ),
+                colour=discord.Colour.red(),
+            )
+            embed.add_field(name="Request ID", value=request.request_id, inline=False)
+            embed.add_field(name="Approval ID", value=request.id, inline=False)
+            try:
+                await channel.send(embed=embed)
+            except discord.HTTPException:
+                logger.exception(
+                    "Failed to post auto-deny notice for request %s", request.id
+                )
+            return ApprovalDecision.DENIED
+
+        message = await channel.send(
+            embed=self._build_pending_embed(request, rendered_args)
+        )
         try:
             await message.add_reaction("✅")
             await message.add_reaction("❌")
@@ -230,7 +265,9 @@ class DiscordApprovalManager(ApprovalManager):
         self._channel = channel
         return channel
 
-    def _build_pending_embed(self, request: ApprovalRequest) -> discord.Embed:
+    def _build_pending_embed(
+        self, request: ApprovalRequest, rendered_args: str
+    ) -> discord.Embed:
         embed = discord.Embed(
             title="Write operation requires approval",
             description=f"Tool `{request.tool_name}` requested write access.",
@@ -241,11 +278,7 @@ class DiscordApprovalManager(ApprovalManager):
         if request.client_id:
             embed.add_field(name="Client ID", value=request.client_id, inline=False)
         if request.arguments:
-            embed.add_field(
-                name="Arguments",
-                value=self._format_arguments(request.arguments),
-                inline=False,
-            )
+            embed.add_field(name="Arguments", value=rendered_args, inline=False)
         embed.set_footer(text="React with ✅ to approve or ❌ to deny.")
         return embed
 
@@ -267,12 +300,6 @@ class DiscordApprovalManager(ApprovalManager):
         embed.add_field(name="Approval ID", value=request.id, inline=False)
         if request.client_id:
             embed.add_field(name="Client ID", value=request.client_id, inline=False)
-        if request.arguments:
-            embed.add_field(
-                name="Arguments",
-                value=self._format_arguments(request.arguments),
-                inline=False,
-            )
         if actor is not None:
             embed.add_field(
                 name="Actor", value=f"{actor} (ID: {actor.id})", inline=False
@@ -289,15 +316,14 @@ class DiscordApprovalManager(ApprovalManager):
     @staticmethod
     def _format_arguments(arguments: Mapping[str, str]) -> str:
         if not arguments:
-            return "`<none>`"
+            return "```\n<none>\n```"
 
-        lines: list[str] = []
-        for key, value in arguments.items():
-            lines.append(f"`{key}` = {value}")
-        rendered = "\n".join(lines)
-        if len(rendered) > 1000:
-            return f"{rendered[:997]}..."
-        return rendered
+        lines = [f"{key} = {value}" for key, value in arguments.items()]
+        # Backticks in values are attacker-controlled (LLM-supplied) and would
+        # close the code fence early, re-enabling live markdown. Substitute a
+        # visually similar non-metacharacter so the fence cannot be broken.
+        body = "\n".join(lines).replace("`", "ˋ")
+        return f"```\n{body}\n```"
 
     @staticmethod
     def _colour_for_decision(decision: ApprovalDecision) -> discord.Colour:

--- a/src/schwab_mcp/tools/_registration.py
+++ b/src/schwab_mcp/tools/_registration.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import suppress
 import functools
 import inspect
+import json
 import logging
 import sys
 import types
@@ -23,6 +24,7 @@ ToolFn = Callable[..., Awaitable[Any]]
 
 _APPROVAL_PROGRESS_INTERVAL = 5.0
 _APPROVAL_WAIT_MESSAGE = "Waiting for reviewer approval…"
+_REDACTED_ARG_NAMES = frozenset({"account_hash"})
 
 
 def _is_context_annotation(annotation: Any) -> bool:
@@ -114,10 +116,14 @@ def _ensure_schwab_context(func: ToolFn) -> ToolFn:
 
 
 def _format_argument(value: Any) -> str:
-    text = repr(value)
-    if len(text) > 256:
-        return f"{text[:253]}..."
-    return text
+    return json.dumps(value, default=repr)
+
+
+def _redact(name: str, value: Any) -> Any:
+    if name not in _REDACTED_ARG_NAMES:
+        return value
+    raw = str(value)
+    return f"…{raw[-4:]}" if len(raw) > 4 else "…"
 
 
 def _wrap_with_approval(func: ToolFn) -> ToolFn:
@@ -157,7 +163,7 @@ def _wrap_with_approval(func: ToolFn) -> ToolFn:
             )
 
         arguments = {
-            name: _format_argument(arg)
+            name: _format_argument(_redact(name, arg))
             for name, arg in bound.arguments.items()
             if name not in ctx_params
         }

--- a/tests/test_approval_wrapping.py
+++ b/tests/test_approval_wrapping.py
@@ -1,4 +1,6 @@
 import asyncio
+import datetime
+import json
 from types import SimpleNamespace
 from typing import Any, Awaitable, TypeVar, cast
 
@@ -112,7 +114,7 @@ def test_write_tool_runs_when_approved() -> None:
     assert len(approval_manager.requests) == 1
     request = approval_manager.requests[0]
     assert request.tool_name == "sample_write_tool"
-    assert request.arguments["symbol"] == "'spy'"
+    assert request.arguments["symbol"] == '"spy"'
     assert session.messages == []
 
 
@@ -177,3 +179,146 @@ def test_discord_manager_requires_approvers() -> None:
     )
     with pytest.raises(ValueError):
         DiscordApprovalManager(settings)
+
+
+def test_format_argument_returns_full_json_without_truncation() -> None:
+    big = {"legs": [{"sym": f"SPY {i}", "qty": i} for i in range(50)]}
+    out = _registration._format_argument(big)
+    assert out == json.dumps(big)
+    assert len(out) > 256
+    assert not out.endswith("...")
+
+
+def test_format_argument_handles_non_json_values() -> None:
+    out = _registration._format_argument({"d": datetime.date(2024, 1, 2)})
+    assert "2024" in out
+
+
+def test_redact_masks_account_hash_to_last_four() -> None:
+    assert _registration._redact("account_hash", "ABCDEFGHIJ") == "…GHIJ"
+    assert _registration._redact("account_hash", "abc") == "…"
+    assert _registration._redact("symbol", "ABCDEFGHIJ") == "ABCDEFGHIJ"
+
+
+async def sample_order_tool(ctx: SchwabContext, account_hash: str, symbol: str) -> str:
+    return f"{account_hash}:{symbol}"
+
+
+def test_account_hash_redacted_in_approval_request() -> None:
+    ctx, approval_manager, _, _ = make_ctx(ApprovalDecision.APPROVED)
+    ensured = _registration._ensure_schwab_context(sample_order_tool)
+    tool = _registration._wrap_with_approval(ensured)
+
+    result = await_result(tool(ctx, "ABCD1234WXYZ", "AAPL"))
+
+    assert result == "ABCD1234WXYZ:AAPL"
+    request = approval_manager.requests[0]
+    assert request.arguments["account_hash"] == '"\\u2026WXYZ"'
+    assert request.arguments["symbol"] == '"AAPL"'
+
+
+def test_discord_format_arguments_wraps_in_code_fence() -> None:
+    out = DiscordApprovalManager._format_arguments({"symbol": '"AAPL"', "qty": "10"})
+    assert out.startswith("```\n")
+    assert out.endswith("\n```")
+    assert 'symbol = "AAPL"' in out
+    assert "qty = 10" in out
+
+
+def test_discord_format_arguments_sanitizes_backticks() -> None:
+    out = DiscordApprovalManager._format_arguments(
+        {"symbol": '"AAPL ``` [evil](https://x)"'}
+    )
+    assert out.count("```") == 2
+    assert "`" not in out.removeprefix("```").removesuffix("```")
+
+
+def test_discord_format_arguments_never_truncates() -> None:
+    big = {"spec": "x" * 2000}
+    out = DiscordApprovalManager._format_arguments(big)
+    assert "x" * 2000 in out
+    assert not out.endswith("...")
+
+
+def _make_discord_manager() -> DiscordApprovalManager:
+    return DiscordApprovalManager(
+        DiscordApprovalSettings(
+            token="token",
+            channel_id=123,
+            approver_ids=frozenset({1}),
+        )
+    )
+
+
+def test_discord_finalize_message_omits_arguments() -> None:
+    manager = _make_discord_manager()
+
+    captured: dict[str, Any] = {}
+
+    class FakeMessage:
+        async def edit(self, *, embed: Any) -> None:
+            captured["embed"] = embed
+
+    request = ApprovalRequest(
+        id="approval-1",
+        tool_name="place_equity_order",
+        request_id="req-1",
+        client_id=None,
+        arguments={"account_hash": '"…WXYZ"', "symbol": '"AAPL"'},
+    )
+
+    await_result(
+        manager._finalize_message(
+            cast(Any, FakeMessage()),
+            request,
+            ApprovalDecision.APPROVED,
+            actor=None,
+            reason=None,
+        )
+    )
+
+    embed = captured["embed"]
+    field_names = [f.name for f in embed.fields]
+    assert "Arguments" not in field_names
+
+
+def test_discord_require_auto_denies_when_arguments_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _make_discord_manager()
+
+    sent: list[Any] = []
+
+    class FakeMessage:
+        id = 999
+
+        async def add_reaction(self, _: str) -> None:
+            raise AssertionError("reactions must not be added on auto-deny path")
+
+    class FakeChannel:
+        async def send(self, *, embed: Any) -> Any:
+            sent.append(embed)
+            return FakeMessage()
+
+    async def fake_start(self: DiscordApprovalManager) -> None:
+        return None
+
+    async def fake_ensure_channel(self: DiscordApprovalManager) -> Any:
+        return FakeChannel()
+
+    monkeypatch.setattr(DiscordApprovalManager, "start", fake_start)
+    monkeypatch.setattr(DiscordApprovalManager, "_ensure_channel", fake_ensure_channel)
+
+    request = ApprovalRequest(
+        id="approval-2",
+        tool_name="place_option_combo_order",
+        request_id="req-2",
+        client_id=None,
+        arguments={"legs": "x" * 1200},
+    )
+
+    decision = await_result(manager.require(request))
+
+    assert decision is ApprovalDecision.DENIED
+    assert len(sent) == 1
+    assert "auto-denied" in sent[0].title.lower()


### PR DESCRIPTION
Makes the Discord approval embed show the reviewer **exactly** what the server will execute — no silent truncation, no live markdown, no account identifier — and auto-denies anything too big to display in full.

## What / Why

| # | What changed | Why |
|---|---|---|
| 1 | `_format_argument` now returns full `json.dumps(value)` with no length cap (was: `repr()` truncated to 253 chars) | The reviewer was shown a `...`-truncated preview while the server executed the full original. Multi-leg combos and OCO dict specs already overflow 253 chars for *legitimate* orders. |
| 2 | `account_hash` is redacted to `…<last4>` before it enters the `ApprovalRequest` | The hash adds nothing to the approve/deny decision but is the exact identifier `place_order` needs — and it was being posted to Discord and kept forever. |
| 3 | The Arguments block is rendered inside a fenced ```` ``` ```` code block, with backticks in the content substituted out so the fence can't be closed from inside | Values were rendered as live Discord markdown. An attacker-influenced `symbol` could embed `[masked links](https://phish)` or strikethrough that hid the real quantity. |
| 4 | If the rendered Arguments block would exceed Discord's ~1000-char field limit, `require()` posts an **auto-deny** notice and returns `DENIED` — it never truncates | Fail closed: the reviewer can never approve something they couldn't fully see. |
| 5 | The **finalized** (post-decision) embed no longer includes the Arguments field | The permanent channel history stops retaining trade specifics. The pending embed still shows them so the reviewer can decide. |
| 6 | `docs/discord-setup.md` now tells you to make the approval channel private | The `--discord-approver` allow-list only governs whose reaction counts, not who can read the channel. |

## Where things changed

```
src/schwab_mcp/
├── tools/_registration.py ──── rows 1, 2   (_format_argument → json.dumps; new _redact())
└── approvals/discord.py ────── rows 3, 4, 5
                                 ├─ _format_arguments → code-fence + backtick sanitize, no truncation
                                 ├─ require() → length-check + auto-deny path
                                 ├─ _build_pending_embed → takes pre-rendered args string
                                 └─ _finalize_message → Arguments field removed
docs/discord-setup.md ───────── row 6
tests/test_approval_wrapping.py ─ 9 new tests covering rows 1-5
```

## How I know it works

- **Full suite:** `pytest` → **310 passed** (baseline on `main` was 301; +9 new tests, 0 regressions).
- **Type check:** `pyright` → 0 errors, 0 warnings.
- **Lint/format:** `ruff format` + `ruff check` → clean on all changed files.
- **New tests cover each row:**
  - row 1: `test_format_argument_returns_full_json_without_truncation`, `test_format_argument_handles_non_json_values`
  - row 2: `test_redact_masks_account_hash_to_last_four`, `test_account_hash_redacted_in_approval_request`
  - row 3: `test_discord_format_arguments_wraps_in_code_fence`, `test_discord_format_arguments_sanitizes_backticks`, `test_discord_format_arguments_never_truncates`
  - row 4: `test_discord_require_auto_denies_when_arguments_overflow`
  - row 5: `test_discord_finalize_message_omits_arguments`

Closes #2
Closes #6
Closes #7
