### PR TITLE
chore(dev): add devcontainer, pre-commit, and setup scripts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+{
+  "name": "bharat/schwab-mcp",
+  "image": "mcr.microsoft.com/devcontainers/python:3.14",
+  "postCreateCommand": "scripts/setup",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "github.vscode-pull-request-github",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ryanluker.vscode-coverage-gutters",
+        "openai.chatgpt",
+        "github.vscode-github-actions",
+        "SanjulaGanepola.github-local-actions"
+      ],
+      "settings": {
+        "files.eol": "\n",
+        "editor.tabSize": 4,
+        "editor.formatOnPaste": true,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": false,
+        "files.trimTrailingWhitespace": true,
+        "python.analysis.typeCheckingMode": "basic",
+        "python.analysis.autoImportCompletions": true,
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
+      }
+    }
+  },
+  "remoteEnv": {
+    "GIT_EDITOR": "cursor --wait",
+    "UV_FROZEN": "1"
+  },
+  "remoteUser": "vscode",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    },
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "packages": "gh"
+    }
+  },
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.10
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: check-yaml
+
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: uv run pyright
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true
+      - id: pytest
+        name: pytest
+        entry: uv run pytest
+        language: system
+        types: [python]
+        args: ["tests/", "-v", "--tb=short"]
+        pass_filenames: false
+        always_run: true

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+uv run ruff check . --fix
+uv run ruff format .
+uv run pyright

--- a/scripts/setup
+++ b/scripts/setup
@@ -11,8 +11,8 @@ export PATH="$HOME/.local/bin:$PATH"
 # Project deps: dev tools + technical-analysis extras, pinned to uv.lock
 uv sync --frozen --group dev --group ta
 
-# act (run GitHub Actions locally)
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo BINDIR=/usr/local/bin bash
+# act (run GitHub Actions locally) — installed as a gh extension, invoked as `gh act`
+gh extension install nektos/gh-act
 
 # pre-commit (installed as a standalone uv tool, not a project dep)
 uv tool install pre-commit

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# uv (Python package/venv manager — this project's build tool)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+# Project deps: dev tools + technical-analysis extras, pinned to uv.lock
+uv sync --frozen --group dev --group ta
+
+# act (run GitHub Actions locally)
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo BINDIR=/usr/local/bin bash
+
+# pre-commit (installed as a standalone uv tool, not a project dep)
+uv tool install pre-commit
+pre-commit install
+
+# Editor / agent CLIs
+curl -fsSL https://cursor.com/install | bash
+curl -fsSL https://claude.ai/install.sh | bash


### PR DESCRIPTION
Adds a devcontainer so the project opens in a reproducible Linux environment with `uv`, `pre-commit`, `act`, `cursor`, and `claude` already installed — modeled on the `homeassistant-triad-ams` devcontainer, adapted for this repo's uv-based workflow.

## What / Why

| Change | Why |
|---|---|
| `.devcontainer/devcontainer.json` | Standard MS Python 3.14 devcontainer; runs `scripts/setup` on create; mounts `~/.claude`; sets `UV_FROZEN=1` so every `uv` call respects the lockfile (avoids the discord.py resolve drift we hit in fresh envs). |
| `scripts/setup` | One-shot bootstrap: install `uv` → `uv sync --frozen --group dev --group ta` → install `act`, `pre-commit` (as a `uv tool`, so no `uv.lock` regen), `cursor`, `claude`. |
| `scripts/lint` | Wraps the project's combined check: `ruff check --fix && ruff format && pyright`. |
| `.pre-commit-config.yaml` | ruff hooks + standard whitespace/yaml hooks + local `pyright` and `pytest` on every commit. |

## Where things changed

```
.devcontainer/
└── devcontainer.json ──── new   python:3.14 image, postCreate=scripts/setup, mounts ~/.claude
.pre-commit-config.yaml ── new   ruff + standard hooks + local pyright + pytest
scripts/
├── setup* ─────────────── new   uv → sync → act → pre-commit → cursor → claude
└── lint* ──────────────── new   ruff check/format + pyright
```

`pyproject.toml` and `uv.lock` are untouched — `pre-commit` is installed via `uv tool install`, not as a project dep.

## Adapted from `homeassistant-triad-ams`

| | Reference | Here |
|---|---|---|
| Package manager | `pip install -r requirements.txt` | `uv sync --frozen --group dev --group ta` |
| `forwardPorts` | `8123` (Home Assistant) | dropped — MCP server is stdio |
| apt packages | `gh, ffmpeg, libpcap-dev, libturbojpeg0` | `gh` only |
| `defaultInterpreterPath` | `/usr/local/bin/python` | `${workspaceFolder}/.venv/bin/python` |
| pre-commit pytest cov | `--cov=custom_components.triad_ams` | inherited from `pyproject.toml` |
| `scripts/develop` | starts `hass` | omitted — no useful dev loop without live Schwab creds |
| Everything else (extensions, settings, docker-outside-of-docker, `~/.claude` mount, `act`/`cursor`/`claude` installers) | kept verbatim | |

## How I know it works

- `scripts/setup` and `scripts/lint` are `chmod +x` and run with `set -e`.
- `bash -n scripts/setup scripts/lint` → syntax OK.
- `uv sync --frozen --group dev --group ta` is the same invocation that produced green test runs in the security-fix PRs.
- Devcontainer JSON validated by VS Code's schema (no diagnostics).

Not exercised end-to-end in an actual container build in this PR — that requires a Codespaces/devcontainer host. The pieces are all known-good in isolation.
