### PR TITLE
feat(approvals): add Signal approval backend via signal-cli daemon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Copy to .env and fill in real values. .env and .env.local are gitignored.
+# scripts/signal-* source .env automatically; the CLI reads the SCHWAB_* vars
+# via click envvar= so `set -a; source .env; set +a` works there too.
+
+# --- Schwab API ---------------------------------------------------------------
+SCHWAB_CLIENT_ID=
+SCHWAB_CLIENT_SECRET=
+SCHWAB_CALLBACK_URL=https://127.0.0.1:8182
+# SCHWAB_BASE_URL=https://api.schwabapi.com
+
+# --- Signal approval backend --------------------------------------------------
+# Bot account the signal-cli daemon is registered as (E.164, e.g. +15555550100)
+SCHWAB_MCP_SIGNAL_ACCOUNT=
+# Your number — replies from this number are honoured (E.164)
+SCHWAB_MCP_SIGNAL_APPROVERS=
+# Where the daemon is reachable from inside the devcontainer
+SCHWAB_MCP_SIGNAL_API_URL=http://host.docker.internal:8080
+# SCHWAB_MCP_SIGNAL_TIMEOUT=600
+
+# --- signal-cli-rest-api container (scripts/signal-daemon) --------------------
+# SIGNAL_API_PORT=8080
+# SIGNAL_API_CONTAINER=signal-api
+
+# --- Discord approval backend (alternative to Signal) -------------------------
+# SCHWAB_MCP_DISCORD_TOKEN=
+# SCHWAB_MCP_DISCORD_CHANNEL_ID=
+# SCHWAB_MCP_DISCORD_APPROVERS=
+# SCHWAB_MCP_DISCORD_TIMEOUT=600

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ info/
 
 # Environment files
 .env
+.env.local
 
 # Python
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The **Schwab Model Context Protocol (MCP) Server** connects your Schwab account 
 *   **Market Data**: Real-time quotes, price history, option chains, and market movers.
 *   **Account Management**: View balances, positions, and transactions.
 *   **Trading**: comprehensive support for equities and options, including complex strategies (OCO, Bracket).
-*   **Safety First**: Critical actions (like trading) are gated behind a **Discord approval workflow** by default.
+*   **Safety First**: Critical actions (like trading) are gated behind a **Discord or Signal approval workflow** by default.
 *   **LLM Integration**: Designed specifically for Agentic AI workflows.
 
 ## Quick Start
@@ -57,13 +57,20 @@ Start the MCP server to expose the tools to your MCP client.
 # Basic Read-Only Mode (Safest) — credentials read from save-credentials file
 schwab-mcp server
 
-# With Trading Enabled (Requires Discord Approval)
+# With Trading Enabled (Discord approval)
 schwab-mcp server \
   --discord-channel-id CHANNEL_ID \
   --discord-approver YOUR_USER_ID
+
+# With Trading Enabled (Signal approval)
+schwab-mcp server \
+  --signal-account +15555550100 \
+  --signal-approver +15555550199
 ```
 
-> **Note**: For trading capabilities, you must set up a Discord bot for approvals. See [Discord Setup Guide](docs/discord-setup.md).
+> **Note**: For trading capabilities you must configure an approval backend.
+> See the [Discord Setup Guide](docs/discord-setup.md) or
+> [Signal Setup Guide](docs/signal-setup.md).
 
 ## Configuration
 
@@ -80,8 +87,10 @@ You can configure the server using CLI flags or Environment Variables.
 | `--client-secret` | `SCHWAB_CLIENT_SECRET` | **Required**. Schwab App Secret. |
 | `--callback-url` | `SCHWAB_CALLBACK_URL` | Redirect URL (default: `https://127.0.0.1:8182`). |
 | `--discord-token` | `SCHWAB_MCP_DISCORD_TOKEN` | Discord bot token for trade approvals. |
+| `--signal-account` | `SCHWAB_MCP_SIGNAL_ACCOUNT` | E.164 number the local signal-cli daemon is registered as. |
+| `--signal-approver` | `SCHWAB_MCP_SIGNAL_APPROVERS` | E.164 number allowed to approve trades (repeatable). |
 | `--token-path` | N/A | Path to save/load token (default: `~/.local/share/...`). |
-| `--jesus-take-the-wheel`| N/A | **DANGER**. Bypasses Discord approval for trades. |
+| `--jesus-take-the-wheel`| N/A | **DANGER**. Bypasses approval for trades. |
 | `--no-technical-tools` | N/A | Disables technical analysis tools (SMA, RSI, etc.). |
 | `--json` | N/A | Returns raw JSON instead of formatted text (useful for some agents). |
 

--- a/docs/signal-setup.md
+++ b/docs/signal-setup.md
@@ -1,0 +1,62 @@
+# Signal approval setup
+
+The Signal approval backend lets you approve or deny trades by replying to a
+Signal message on your phone. It talks to a local
+[`signal-cli`][signal-cli] daemon over HTTP, so the MCP server never needs a
+public inbound endpoint and trade details stay end-to-end encrypted between
+the daemon and your phone.
+
+## What you need
+
+| Thing | Notes |
+|---|---|
+| A second phone number | The daemon registers its **own** Signal account; it cannot share the number your phone uses. A cheap VoIP number works. |
+| `signal-cli-rest-api` running locally | Easiest is the [bbernhard/signal-cli-rest-api][rest] Docker image. |
+| Your own number | Passed as `--signal-approver`; only replies from this number are honoured. |
+
+## One-time registration
+
+```bash
+# 1. Start the REST daemon (persists state in the named volume)
+docker run -d --name signal-api \
+  -p 127.0.0.1:8080:8080 \
+  -v signal-cli-data:/home/.local/share/signal-cli \
+  -e MODE=native \
+  bbernhard/signal-cli-rest-api:latest
+
+# 2. Register the bot number (replace with your VoIP number)
+curl -X POST http://127.0.0.1:8080/v1/register/+15555550100
+
+# 3. Verify with the SMS code Signal sends to that number
+curl -X POST http://127.0.0.1:8080/v1/register/+15555550100/verify/123456
+```
+
+Send yourself a test message to confirm:
+
+```bash
+curl -X POST http://127.0.0.1:8080/v2/send \
+  -H 'Content-Type: application/json' \
+  -d '{"number":"+15555550100","recipients":["+15555550199"],"message":"hello"}'
+```
+
+## Running the server with Signal approvals
+
+```bash
+schwab-mcp server \
+  --client-id "$SCHWAB_CLIENT_ID" \
+  --client-secret "$SCHWAB_CLIENT_SECRET" \
+  --signal-api-url http://127.0.0.1:8080 \
+  --signal-account +15555550100 \
+  --signal-approver +15555550199
+```
+
+When a write tool is invoked you'll receive a Signal message describing the
+tool and its arguments. **Reply to that message** (long-press → Reply) with
+`ok` to approve or `no` to deny. Anything else, or no reply within
+`--signal-timeout` seconds (default 600), is treated as a denial.
+
+You may not configure Discord and Signal approvals at the same time; the
+server wires exactly one approval backend.
+
+[signal-cli]: https://github.com/AsamK/signal-cli
+[rest]: https://github.com/bbernhard/signal-cli-rest-api

--- a/scripts/signal-daemon
+++ b/scripts/signal-daemon
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Manage the local signal-cli-rest-api container used by SignalApprovalManager.
+# Runs on the HOST (needs docker + curl).
+
+set -euo pipefail
+
+CONTAINER=${SIGNAL_API_CONTAINER:-signal-api}
+PORT=${SIGNAL_API_PORT:-8080}
+API="http://127.0.0.1:${PORT}"
+
+usage() {
+    cat <<EOF
+Usage: scripts/signal-daemon <command> [args]
+
+  up                          start the signal-cli-rest-api container (idempotent)
+  down                        stop and remove it (registration data persists in the volume)
+  logs                        follow daemon logs
+  register <bot-number>       begin registration; Signal sends an SMS code to that number
+  verify   <bot-number> <code>  complete registration with the SMS code
+  send     <bot> <to> <text>  sanity-check: send <text> from <bot> to <to>
+
+Env: SIGNAL_API_PORT (default 8080), SIGNAL_API_CONTAINER (default signal-api)
+EOF
+}
+
+cmd=${1:-}
+shift || true
+
+case "$cmd" in
+    up)
+        if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+            docker start "$CONTAINER"
+        else
+            docker run -d --name "$CONTAINER" \
+                -p "127.0.0.1:${PORT}:8080" \
+                -v signal-cli-data:/home/.local/share/signal-cli \
+                -e MODE=native \
+                bbernhard/signal-cli-rest-api:latest
+        fi
+        echo "signal-cli-rest-api listening on ${API}"
+        ;;
+    down)
+        docker rm -f "$CONTAINER"
+        ;;
+    logs)
+        docker logs -f "$CONTAINER"
+        ;;
+    register)
+        [ $# -eq 1 ] || { usage; exit 1; }
+        curl -fsS -X POST "${API}/v1/register/$1" && echo
+        ;;
+    verify)
+        [ $# -eq 2 ] || { usage; exit 1; }
+        curl -fsS -X POST "${API}/v1/register/$1/verify/$2" && echo
+        ;;
+    send)
+        [ $# -eq 3 ] || { usage; exit 1; }
+        curl -fsS -X POST "${API}/v2/send" \
+            -H 'Content-Type: application/json' \
+            -d "{\"number\":\"$1\",\"recipients\":[\"$2\"],\"message\":\"$3\"}" && echo
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/scripts/signal-daemon
+++ b/scripts/signal-daemon
@@ -3,6 +3,7 @@
 # Runs on the HOST (needs docker + curl).
 
 set -euo pipefail
+[ -f .env ] && set -a && source .env && set +a
 
 CONTAINER=${SIGNAL_API_CONTAINER:-signal-api}
 PORT=${SIGNAL_API_PORT:-8080}

--- a/scripts/signal-server
+++ b/scripts/signal-server
@@ -3,6 +3,7 @@
 # Runs on the HOST; the server itself runs in the container.
 
 set -euo pipefail
+[ -f .env ] && set -a && source .env && set +a
 
 : "${SCHWAB_MCP_SIGNAL_ACCOUNT:?set SCHWAB_MCP_SIGNAL_ACCOUNT to the bot E.164 number}"
 : "${SCHWAB_MCP_SIGNAL_APPROVERS:?set SCHWAB_MCP_SIGNAL_APPROVERS to your E.164 number}"

--- a/scripts/signal-server
+++ b/scripts/signal-server
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Run the MCP server inside the devcontainer with Signal approvals wired up.
+# Runs on the HOST; the server itself runs in the container.
+
+set -euo pipefail
+
+: "${SCHWAB_MCP_SIGNAL_ACCOUNT:?set SCHWAB_MCP_SIGNAL_ACCOUNT to the bot E.164 number}"
+: "${SCHWAB_MCP_SIGNAL_APPROVERS:?set SCHWAB_MCP_SIGNAL_APPROVERS to your E.164 number}"
+API_URL=${SCHWAB_MCP_SIGNAL_API_URL:-http://host.docker.internal:8080}
+
+exec devcontainer exec --workspace-folder . -- \
+    uv run schwab-mcp server \
+        --signal-api-url "$API_URL" \
+        --signal-account "$SCHWAB_MCP_SIGNAL_ACCOUNT" \
+        --signal-approver "$SCHWAB_MCP_SIGNAL_APPROVERS" \
+        "$@"

--- a/scripts/signal-test
+++ b/scripts/signal-test
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Send one fake approval request through SignalApprovalManager and wait for a
+# reply on your phone. No Schwab auth, no MCP client, no real trade.
+# Runs on the HOST; executes inside the devcontainer where the venv lives.
+
+set -euo pipefail
+
+: "${SCHWAB_MCP_SIGNAL_ACCOUNT:?set SCHWAB_MCP_SIGNAL_ACCOUNT to the bot E.164 number}"
+: "${SCHWAB_MCP_SIGNAL_APPROVERS:?set SCHWAB_MCP_SIGNAL_APPROVERS to your E.164 number}"
+API_URL=${SCHWAB_MCP_SIGNAL_API_URL:-http://host.docker.internal:8080}
+TIMEOUT=${1:-120}
+
+exec devcontainer exec --workspace-folder . -- \
+    uv run scripts/smoke-signal \
+        --api-url "$API_URL" \
+        --account "$SCHWAB_MCP_SIGNAL_ACCOUNT" \
+        --approver "$SCHWAB_MCP_SIGNAL_APPROVERS" \
+        --timeout "$TIMEOUT"

--- a/scripts/signal-test
+++ b/scripts/signal-test
@@ -4,6 +4,7 @@
 # Runs on the HOST; executes inside the devcontainer where the venv lives.
 
 set -euo pipefail
+[ -f .env ] && set -a && source .env && set +a
 
 : "${SCHWAB_MCP_SIGNAL_ACCOUNT:?set SCHWAB_MCP_SIGNAL_ACCOUNT to the bot E.164 number}"
 : "${SCHWAB_MCP_SIGNAL_APPROVERS:?set SCHWAB_MCP_SIGNAL_APPROVERS to your E.164 number}"

--- a/scripts/smoke-signal
+++ b/scripts/smoke-signal
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""Manual smoke test for SignalApprovalManager.
+
+Sends one fake approval request and waits for a reply. No Schwab, no MCP.
+
+    uv run scripts/smoke-signal \
+        --api-url http://host.docker.internal:8080 \
+        --account +1555BOTNUMBER \
+        --approver +1555YOURNUMBER
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import uuid
+
+from schwab_mcp.approvals import (
+    ApprovalRequest,
+    SignalApprovalManager,
+    SignalApprovalSettings,
+)
+
+
+async def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--api-url", default="http://127.0.0.1:8080")
+    p.add_argument("--account", required=True)
+    p.add_argument("--approver", required=True, action="append")
+    p.add_argument("--timeout", type=float, default=120.0)
+    args = p.parse_args()
+
+    mgr = SignalApprovalManager(
+        SignalApprovalSettings(
+            api_url=args.api_url,
+            account=args.account,
+            approver_numbers=frozenset(args.approver),
+            timeout_seconds=args.timeout,
+        )
+    )
+    req = ApprovalRequest(
+        id=uuid.uuid4().hex[:6],
+        tool_name="place_equity_order",
+        request_id="smoke-test",
+        client_id=None,
+        arguments={
+            "symbol": '"NVDA"',
+            "quantity": "50",
+            "instruction": '"BUY"',
+            "order_type": '"LIMIT"',
+            "price": "904.50",
+            "account_hash": '"\\u2026WXYZ"',
+        },
+    )
+    print(f"Sending approval request {req.id} — check your phone...")
+    try:
+        decision = await mgr.require(req)
+    finally:
+        await mgr.stop()
+    print(f"Decision: {decision.value}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/schwab_mcp/approvals/__init__.py
+++ b/src/schwab_mcp/approvals/__init__.py
@@ -10,6 +10,10 @@ from schwab_mcp.approvals.discord import (
     DiscordApprovalManager,
     DiscordApprovalSettings,
 )
+from schwab_mcp.approvals.signal import (
+    SignalApprovalManager,
+    SignalApprovalSettings,
+)
 
 __all__ = [
     "ApprovalDecision",
@@ -18,4 +22,6 @@ __all__ = [
     "NoOpApprovalManager",
     "DiscordApprovalManager",
     "DiscordApprovalSettings",
+    "SignalApprovalManager",
+    "SignalApprovalSettings",
 ]

--- a/src/schwab_mcp/approvals/base.py
+++ b/src/schwab_mcp/approvals/base.py
@@ -25,6 +25,22 @@ class ApprovalRequest:
     arguments: Mapping[str, str]
 
 
+def format_arguments(arguments: Mapping[str, str]) -> str:
+    """Render approval arguments as a fenced text block.
+
+    Backticks in values are attacker-controlled (LLM-supplied) and would close
+    a markdown code fence early, re-enabling live formatting. Substitute a
+    visually similar non-metacharacter so the fence cannot be broken. Shared
+    by all approval backends so the redaction-safe rendering stays consistent.
+    """
+    if not arguments:
+        return "```\n<none>\n```"
+
+    lines = [f"{key} = {value}" for key, value in arguments.items()]
+    body = "\n".join(lines).replace("`", "ˋ")
+    return f"```\n{body}\n```"
+
+
 class ApprovalManager(abc.ABC):
     """Interface for asynchronous approval backends."""
 
@@ -51,4 +67,5 @@ __all__ = [
     "ApprovalManager",
     "ApprovalRequest",
     "NoOpApprovalManager",
+    "format_arguments",
 ]

--- a/src/schwab_mcp/approvals/discord.py
+++ b/src/schwab_mcp/approvals/discord.py
@@ -11,6 +11,7 @@ from schwab_mcp.approvals.base import (
     ApprovalDecision,
     ApprovalManager,
     ApprovalRequest,
+    format_arguments,
 )
 
 
@@ -315,15 +316,7 @@ class DiscordApprovalManager(ApprovalManager):
 
     @staticmethod
     def _format_arguments(arguments: Mapping[str, str]) -> str:
-        if not arguments:
-            return "```\n<none>\n```"
-
-        lines = [f"{key} = {value}" for key, value in arguments.items()]
-        # Backticks in values are attacker-controlled (LLM-supplied) and would
-        # close the code fence early, re-enabling live markdown. Substitute a
-        # visually similar non-metacharacter so the fence cannot be broken.
-        body = "\n".join(lines).replace("`", "ˋ")
-        return f"```\n{body}\n```"
+        return format_arguments(arguments)
 
     @staticmethod
     def _colour_for_decision(decision: ApprovalDecision) -> discord.Colour:

--- a/src/schwab_mcp/approvals/signal.py
+++ b/src/schwab_mcp/approvals/signal.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from schwab_mcp.approvals.base import (
+    ApprovalDecision,
+    ApprovalManager,
+    ApprovalRequest,
+    format_arguments,
+)
+
+logger = logging.getLogger(__name__)
+
+# Signal's per-message text limit is ~2000 chars; leave headroom for the
+# header/footer so the rendered arguments are never partially shown.
+_BODY_LIMIT = 1800
+
+_APPROVE_WORDS = frozenset({"ok", "yes", "y", "approve", "approved", "✅", "👍"})
+_DENY_WORDS = frozenset({"no", "n", "deny", "denied", "❌", "👎"})
+
+
+@dataclass(slots=True, frozen=True)
+class SignalApprovalSettings:
+    """Configuration values required for Signal approvals."""
+
+    api_url: str
+    account: str
+    approver_numbers: frozenset[str]
+    timeout_seconds: float = 600.0
+
+
+@dataclass(slots=True)
+class _PendingApproval:
+    request: ApprovalRequest
+    future: asyncio.Future[ApprovalDecision]
+    sent_timestamp: int
+
+
+class SignalApprovalManager(ApprovalManager):
+    """Approval manager that routes decisions through Signal replies.
+
+    Talks to a local signal-cli REST daemon (bbernhard/signal-cli-rest-api or
+    ``signal-cli daemon --http``) so no public endpoint is exposed. Correlation
+    uses Signal's native reply-to: the daemon returns the sent message's
+    timestamp, and an incoming reply carries that timestamp in ``quote.id``.
+    """
+
+    def __init__(self, settings: SignalApprovalSettings) -> None:
+        if not settings.approver_numbers:
+            raise ValueError(
+                "SignalApprovalManager requires at least one approver number."
+            )
+        self._settings = settings
+        self._client = httpx.AsyncClient(base_url=settings.api_url, timeout=None)
+        self._receiver: asyncio.Task[None] | None = None
+        self._pending: dict[int, _PendingApproval] = {}
+        self._lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        if self._receiver is not None:
+            return
+        loop = asyncio.get_running_loop()
+        self._receiver = loop.create_task(self._receive_loop())
+
+    async def stop(self) -> None:
+        if self._receiver is not None:
+            self._receiver.cancel()
+            try:
+                await self._receiver
+            except asyncio.CancelledError:
+                pass
+            self._receiver = None
+        await self._client.aclose()
+
+    async def require(self, request: ApprovalRequest) -> ApprovalDecision:
+        await self.start()
+
+        rendered_args = format_arguments(request.arguments)
+        body = self._build_body(request, rendered_args)
+        if len(body) > _BODY_LIMIT:
+            logger.warning(
+                "Auto-denying approval %s for tool '%s': body too large to "
+                "display in full (%d chars)",
+                request.id,
+                request.tool_name,
+                len(body),
+            )
+            await self._send_best_effort(
+                f"❌ schwab-mcp auto-denied '{request.tool_name}' "
+                f"(approval {request.id}): arguments too large to display in "
+                f"full ({len(body)} chars). Approving a partial view is unsafe."
+            )
+            return ApprovalDecision.DENIED
+
+        sent_timestamp = await self._send(body)
+        future: asyncio.Future[ApprovalDecision] = (
+            asyncio.get_running_loop().create_future()
+        )
+        pending = _PendingApproval(
+            request=request, future=future, sent_timestamp=sent_timestamp
+        )
+        async with self._lock:
+            self._pending[sent_timestamp] = pending
+
+        try:
+            decision = await asyncio.wait_for(
+                future, timeout=self._settings.timeout_seconds
+            )
+        except asyncio.TimeoutError:
+            decision = ApprovalDecision.EXPIRED
+            await self._send_best_effort(
+                f"⏱️ schwab-mcp approval {request.id} for "
+                f"'{request.tool_name}' expired after "
+                f"{int(self._settings.timeout_seconds)}s."
+            )
+        finally:
+            async with self._lock:
+                self._pending.pop(sent_timestamp, None)
+
+        return decision
+
+    async def _send(self, body: str) -> int:
+        response = await self._client.post(
+            "/v2/send",
+            json={
+                "number": self._settings.account,
+                "recipients": sorted(self._settings.approver_numbers),
+                "message": body,
+            },
+        )
+        response.raise_for_status()
+        return int(response.json()["timestamp"])
+
+    async def _send_best_effort(self, body: str) -> None:
+        try:
+            await self._send(body)
+        except httpx.HTTPError:
+            logger.exception("Failed to post Signal notice")
+
+    async def _receive_loop(self) -> None:
+        while True:
+            try:
+                response = await self._client.get(
+                    f"/v1/receive/{self._settings.account}",
+                    params={"timeout": 30},
+                )
+                response.raise_for_status()
+                for envelope in response.json():
+                    await self._handle_envelope(envelope)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Signal receive loop error; retrying in 5s")
+                await asyncio.sleep(5)
+
+    async def _handle_envelope(self, envelope: dict[str, Any]) -> None:
+        env = envelope.get("envelope", envelope)
+        source = env.get("sourceNumber") or env.get("source")
+        data = env.get("dataMessage") or {}
+        quote = data.get("quote") or {}
+        quoted_ts = quote.get("id")
+        text = (data.get("message") or "").strip().lower()
+
+        if quoted_ts is None or not text:
+            return
+        if source not in self._settings.approver_numbers:
+            logger.debug("Ignoring Signal reply from unauthorized number %s", source)
+            return
+
+        async with self._lock:
+            pending = self._pending.get(int(quoted_ts))
+        if pending is None or pending.future.done():
+            return
+
+        if text in _APPROVE_WORDS:
+            decision = ApprovalDecision.APPROVED
+        elif text in _DENY_WORDS:
+            decision = ApprovalDecision.DENIED
+        else:
+            return
+
+        pending.future.set_result(decision)
+        marker = "✅" if decision is ApprovalDecision.APPROVED else "❌"
+        await self._send_best_effort(
+            f"{marker} schwab-mcp approval {pending.request.id} for "
+            f"'{pending.request.tool_name}' {decision.value} by {source}."
+        )
+
+    def _build_body(self, request: ApprovalRequest, rendered_args: str) -> str:
+        lines = [
+            "⚠️ schwab-mcp: write operation needs approval",
+            "",
+            f"tool        {request.tool_name}",
+            f"approval    {request.id}",
+            f"request     {request.request_id}",
+        ]
+        if request.client_id:
+            lines.append(f"client      {request.client_id}")
+        lines += [
+            "",
+            rendered_args,
+            "",
+            'Reply to this message with "ok" to approve or "no" to deny.',
+            f"Expires in {int(self._settings.timeout_seconds)}s.",
+        ]
+        return "\n".join(lines)
+
+    @staticmethod
+    def authorized_numbers(values: Sequence[str] | None) -> frozenset[str]:
+        """Normalize a sequence of approver phone numbers."""
+        if not values:
+            return frozenset()
+        return frozenset(v.strip() for v in values if v.strip())
+
+
+__all__ = ["SignalApprovalManager", "SignalApprovalSettings"]

--- a/src/schwab_mcp/cli.py
+++ b/src/schwab_mcp/cli.py
@@ -11,6 +11,8 @@ from schwab_mcp.approvals import (
     DiscordApprovalManager,
     DiscordApprovalSettings,
     NoOpApprovalManager,
+    SignalApprovalManager,
+    SignalApprovalSettings,
 )
 
 
@@ -179,6 +181,35 @@ def auth(
     help="Seconds to wait for Discord approval before timing out.",
 )
 @click.option(
+    "--signal-api-url",
+    type=str,
+    default="http://127.0.0.1:8080",
+    show_default=True,
+    envvar="SCHWAB_MCP_SIGNAL_API_URL",
+    help="Base URL of the local signal-cli REST daemon.",
+)
+@click.option(
+    "--signal-account",
+    type=str,
+    envvar="SCHWAB_MCP_SIGNAL_ACCOUNT",
+    help="E.164 number the signal-cli daemon is registered as.",
+)
+@click.option(
+    "--signal-approver",
+    type=str,
+    multiple=True,
+    envvar="SCHWAB_MCP_SIGNAL_APPROVERS",
+    help="E.164 number allowed to approve or deny. Pass multiple times for several reviewers.",
+)
+@click.option(
+    "--signal-timeout",
+    type=int,
+    default=600,
+    show_default=True,
+    envvar="SCHWAB_MCP_SIGNAL_TIMEOUT",
+    help="Seconds to wait for Signal approval before timing out.",
+)
+@click.option(
     "--json",
     "json_output",
     default=False,
@@ -196,6 +227,10 @@ def server(
     discord_channel_id: int | None,
     discord_approver: tuple[str, ...],
     discord_timeout: int,
+    signal_api_url: str,
+    signal_account: str | None,
+    signal_approver: tuple[str, ...],
+    signal_timeout: int,
     no_technical_tools: bool,
     json_output: bool,
 ) -> int:
@@ -276,6 +311,14 @@ def server(
                 approver_values,
             )
         )
+        signal_requested = any((signal_account, signal_approver))
+        if discord_requested and signal_requested:
+            send_error_response(
+                "Configure either Discord or Signal approvals, not both.",
+                code=400,
+                details={"discord": True, "signal": True},
+            )
+            return 1
         allow_write = False
 
         if jesus_take_the_wheel:
@@ -310,6 +353,27 @@ def server(
                 timeout_seconds=float(discord_timeout),
             )
             approval_manager = DiscordApprovalManager(settings)
+            allow_write = True
+        elif signal_requested:
+            approver_numbers = SignalApprovalManager.authorized_numbers(signal_approver)
+            if not signal_account or not approver_numbers:
+                send_error_response(
+                    "Signal approval configuration is required to enable write tools.",
+                    code=400,
+                    details={
+                        "missing_account": not bool(signal_account),
+                        "missing_approvers": not bool(approver_numbers),
+                    },
+                )
+                return 1
+            approval_manager = SignalApprovalManager(
+                SignalApprovalSettings(
+                    api_url=signal_api_url,
+                    account=signal_account,
+                    approver_numbers=approver_numbers,
+                    timeout_seconds=float(signal_timeout),
+                )
+            )
             allow_write = True
         else:
             approval_manager = NoOpApprovalManager()

--- a/tests/test_approval_signal.py
+++ b/tests/test_approval_signal.py
@@ -1,0 +1,210 @@
+import asyncio
+from typing import Any, Awaitable, TypeVar
+
+import pytest
+
+from schwab_mcp.approvals import (
+    ApprovalDecision,
+    ApprovalRequest,
+    SignalApprovalManager,
+    SignalApprovalSettings,
+)
+from schwab_mcp.approvals import signal as signal_mod
+
+T = TypeVar("T")
+
+
+def await_result(awaitable: Awaitable[T]) -> T:
+    async def _runner() -> T:
+        return await awaitable
+
+    return asyncio.run(_runner())
+
+
+def _make_manager(
+    monkeypatch: pytest.MonkeyPatch, *, timeout_seconds: float = 600.0
+) -> tuple[SignalApprovalManager, list[str]]:
+    sent: list[str] = []
+    counter = {"ts": 1000}
+
+    async def fake_send(self: SignalApprovalManager, body: str) -> int:
+        sent.append(body)
+        counter["ts"] += 1
+        return counter["ts"]
+
+    async def fake_start(self: SignalApprovalManager) -> None:
+        return None
+
+    monkeypatch.setattr(SignalApprovalManager, "_send", fake_send)
+    monkeypatch.setattr(SignalApprovalManager, "start", fake_start)
+
+    manager = SignalApprovalManager(
+        SignalApprovalSettings(
+            api_url="http://127.0.0.1:8080",
+            account="+15555550100",
+            approver_numbers=frozenset({"+15555550199"}),
+            timeout_seconds=timeout_seconds,
+        )
+    )
+    return manager, sent
+
+
+def _request(**overrides: Any) -> ApprovalRequest:
+    base: dict[str, Any] = {
+        "id": "appr-1",
+        "tool_name": "place_equity_order",
+        "request_id": "req-1",
+        "client_id": None,
+        "arguments": {"symbol": '"NVDA"', "quantity": "50"},
+    }
+    base.update(overrides)
+    return ApprovalRequest(**base)
+
+
+def _reply(
+    quoted_ts: int, text: str, *, source: str = "+15555550199"
+) -> dict[str, Any]:
+    return {
+        "envelope": {
+            "sourceNumber": source,
+            "dataMessage": {"message": text, "quote": {"id": quoted_ts}},
+        }
+    }
+
+
+def test_signal_manager_requires_approvers() -> None:
+    with pytest.raises(ValueError):
+        SignalApprovalManager(
+            SignalApprovalSettings(
+                api_url="http://127.0.0.1:8080",
+                account="+15555550100",
+                approver_numbers=frozenset(),
+            )
+        )
+
+
+def test_require_approves_on_ok_reply(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager, sent = _make_manager(monkeypatch)
+
+    async def scenario() -> ApprovalDecision:
+        task = asyncio.create_task(manager.require(_request()))
+        await asyncio.sleep(0)
+        (sent_ts,) = list(manager._pending)
+        await manager._handle_envelope(_reply(sent_ts, "ok"))
+        return await task
+
+    decision = await_result(scenario())
+
+    assert decision is ApprovalDecision.APPROVED
+    assert "needs approval" in sent[0]
+    assert "approved" in sent[-1]
+
+
+def test_require_denies_on_no_reply(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager, sent = _make_manager(monkeypatch)
+
+    async def scenario() -> ApprovalDecision:
+        task = asyncio.create_task(manager.require(_request()))
+        await asyncio.sleep(0)
+        (sent_ts,) = list(manager._pending)
+        await manager._handle_envelope(_reply(sent_ts, "NO"))
+        return await task
+
+    assert await_result(scenario()) is ApprovalDecision.DENIED
+    assert "denied" in sent[-1]
+
+
+def test_unauthorized_number_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager, _ = _make_manager(monkeypatch, timeout_seconds=0.05)
+
+    async def scenario() -> ApprovalDecision:
+        task = asyncio.create_task(manager.require(_request()))
+        await asyncio.sleep(0)
+        (sent_ts,) = list(manager._pending)
+        await manager._handle_envelope(_reply(sent_ts, "ok", source="+19998887777"))
+        return await task
+
+    assert await_result(scenario()) is ApprovalDecision.EXPIRED
+
+
+def test_unrecognized_word_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager, _ = _make_manager(monkeypatch, timeout_seconds=0.05)
+
+    async def scenario() -> ApprovalDecision:
+        task = asyncio.create_task(manager.require(_request()))
+        await asyncio.sleep(0)
+        (sent_ts,) = list(manager._pending)
+        await manager._handle_envelope(_reply(sent_ts, "maybe later"))
+        return await task
+
+    assert await_result(scenario()) is ApprovalDecision.EXPIRED
+
+
+def test_reply_without_quote_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager, _ = _make_manager(monkeypatch, timeout_seconds=0.05)
+
+    async def scenario() -> ApprovalDecision:
+        task = asyncio.create_task(manager.require(_request()))
+        await asyncio.sleep(0)
+        await manager._handle_envelope(
+            {
+                "envelope": {
+                    "sourceNumber": "+15555550199",
+                    "dataMessage": {"message": "ok"},
+                }
+            }
+        )
+        return await task
+
+    assert await_result(scenario()) is ApprovalDecision.EXPIRED
+
+
+def test_require_auto_denies_when_body_overflows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, sent = _make_manager(monkeypatch)
+
+    decision = await_result(
+        manager.require(
+            _request(arguments={"legs": "x" * (signal_mod._BODY_LIMIT + 1)})
+        )
+    )
+
+    assert decision is ApprovalDecision.DENIED
+    assert len(sent) == 1
+    assert "auto-denied" in sent[0]
+    assert manager._pending == {}
+
+
+def test_timeout_returns_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager, sent = _make_manager(monkeypatch, timeout_seconds=0.01)
+
+    decision = await_result(manager.require(_request()))
+
+    assert decision is ApprovalDecision.EXPIRED
+    assert "expired" in sent[-1]
+    assert manager._pending == {}
+
+
+def test_build_body_includes_args_and_instructions() -> None:
+    manager = SignalApprovalManager(
+        SignalApprovalSettings(
+            api_url="http://127.0.0.1:8080",
+            account="+15555550100",
+            approver_numbers=frozenset({"+15555550199"}),
+        )
+    )
+    body = manager._build_body(
+        _request(client_id="client-123"),
+        signal_mod.format_arguments({"symbol": '"NVDA"'}),
+    )
+    assert "place_equity_order" in body
+    assert "client-123" in body
+    assert 'symbol = "NVDA"' in body
+    assert '"ok" to approve' in body
+
+
+def test_authorized_numbers_normalizes() -> None:
+    out = SignalApprovalManager.authorized_numbers([" +15555550199 ", "", "+1555"])
+    assert out == frozenset({"+15555550199", "+1555"})
+    assert SignalApprovalManager.authorized_numbers(None) == frozenset()


### PR DESCRIPTION
Adds Signal as a second approval backend alongside Discord, so trades can be approved by replying to a Signal message instead of reacting in a Discord channel.

## What / Why

| What | Why |
|---|---|
| New `SignalApprovalManager` that talks to a local `signal-cli` REST daemon | Lets users who don't run Discord approve trades on their phone, end-to-end encrypted, without exposing a public webhook |
| Correlate via Signal's native reply-to (`quote.id == sent timestamp`) | Same one-tap UX as Discord reactions — no codes to retype |
| Auto-deny when the rendered body would exceed Signal's text limit | Keeps the fail-closed posture from #13 — never ask a human to approve something they can't see in full |
| Lift `_format_arguments` to `approvals.base.format_arguments()` | Both backends share the backtick-swap / code-fence rendering so the redaction guarantees stay identical |
| `--signal-*` CLI flags + mutual-exclusion with `--discord-*` | Slots into the existing selection ladder; exactly one `ApprovalManager` is wired |
| `docs/signal-setup.md` + README mentions | Mirrors `docs/discord-setup.md` so a new user can pick either path |

## Where things changed

```
src/schwab_mcp/approvals/
  base.py           ~  +format_arguments() shared helper
  discord.py        ~  _format_arguments now delegates to the shared helper (behavior unchanged)
  signal.py         +  NEW — settings dataclass + manager
  __init__.py       +  export SignalApprovalManager / SignalApprovalSettings
src/schwab_mcp/cli.py   ~  4 --signal-* options, signal_requested branch, both-configured error
docs/signal-setup.md    +  NEW
tests/test_approval_signal.py  +  NEW — 10 cases
README.md               ~  Signal mentioned alongside Discord
```

No new Python dependency — the manager only uses `httpx`, which is already required. The signal-cli daemon is an external runtime prerequisite documented in `docs/signal-setup.md`.

## How I know it works

| Check | Result |
|---|---|
| `uv run pytest` | 330 passed (10 new), 0 failed |
| `scripts/lint` (ruff check + format + pyright) | clean |
| Existing Discord approval tests | unchanged, still pass |
| `test_cli_server_write_modes.py` | still pass with the new params |
| New tests | approve-via-reply, deny-via-reply, unauthorized number ignored, unrecognized word ignored, reply-without-quote ignored, overflow auto-denies, timeout → EXPIRED, body content, number normalization, requires-approver |

## Out of scope / follow-ups

| Item | Why deferred |
|---|---|
| Editing the sent Signal message after a decision | signal-cli supports it but rendering is inconsistent across clients; v1 sends a follow-up confirmation instead |
| Multi-backend fan-out (Discord *and* Signal at once) | Would need an `ApprovalManager` aggregator in the lifespan; not needed for the single-user case |