### PR TITLE
fix(tools): pass prices as truncated strings to schwab-py builders

### DIFF
--- a/src/schwab_mcp/tools/order_helpers.py
+++ b/src/schwab_mcp/tools/order_helpers.py
@@ -54,7 +54,7 @@ def equity_buy_limit(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(price)
+        .set_price(str(price))
         .add_equity_leg(EquityInstruction.BUY, symbol, quantity)
     )
 
@@ -68,7 +68,7 @@ def equity_sell_limit(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(price)
+        .set_price(str(price))
         .add_equity_leg(EquityInstruction.SELL, symbol, quantity)
     )
 
@@ -82,7 +82,7 @@ def equity_buy_stop(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.STOP)
-        .set_stop_price(stop_price)
+        .set_stop_price(str(stop_price))
         .add_equity_leg(EquityInstruction.BUY, symbol, quantity)
     )
 
@@ -96,7 +96,7 @@ def equity_sell_stop(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.STOP)
-        .set_stop_price(stop_price)
+        .set_stop_price(str(stop_price))
         .add_equity_leg(EquityInstruction.SELL, symbol, quantity)
     )
 
@@ -115,8 +115,8 @@ def equity_buy_stop_limit(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.STOP_LIMIT)
-        .set_stop_price(stop_price)
-        .set_price(limit_price)
+        .set_stop_price(str(stop_price))
+        .set_price(str(limit_price))
         .add_equity_leg(EquityInstruction.BUY, symbol, quantity)
     )
 
@@ -135,8 +135,8 @@ def equity_sell_stop_limit(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.STOP_LIMIT)
-        .set_stop_price(stop_price)
-        .set_price(limit_price)
+        .set_stop_price(str(stop_price))
+        .set_price(str(limit_price))
         .add_equity_leg(EquityInstruction.SELL, symbol, quantity)
     )
 
@@ -214,7 +214,7 @@ def option_buy_to_open_limit(
     return (
         __option_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(price)
+        .set_price(str(price))
         .add_option_leg(OptionInstruction.BUY_TO_OPEN, symbol, quantity)
     )
 
@@ -228,7 +228,7 @@ def option_sell_to_open_limit(
     return (
         __option_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(price)
+        .set_price(str(price))
         .add_option_leg(OptionInstruction.SELL_TO_OPEN, symbol, quantity)
     )
 
@@ -242,7 +242,7 @@ def option_buy_to_close_limit(
     return (
         __option_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(price)
+        .set_price(str(price))
         .add_option_leg(OptionInstruction.BUY_TO_CLOSE, symbol, quantity)
     )
 
@@ -256,7 +256,7 @@ def option_sell_to_close_limit(
     return (
         __option_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(price)
+        .set_price(str(price))
         .add_option_leg(OptionInstruction.SELL_TO_CLOSE, symbol, quantity)
     )
 

--- a/src/schwab_mcp/tools/order_helpers.py
+++ b/src/schwab_mcp/tools/order_helpers.py
@@ -11,6 +11,19 @@ from schwab.orders.common import (
 from schwab.orders.generic import OrderBuilder
 
 
+def _price_str(price: float) -> str:
+    """Format a price the way schwab-py used to before deprecating float input.
+
+    schwab-py's ``set_price``/``set_stop_price`` warn on floats and will drop
+    support; passing a string skips their truncation. Replicate that
+    truncation here so the wire format stays identical: 4 decimals for
+    sub-dollar prices, 2 decimals otherwise, truncated (not rounded).
+    """
+    if price != 0.0 and abs(price) < 1:
+        return f"{int(price * 10000) / 10000.0:.4f}"
+    return f"{int(price * 100) / 100.0:.2f}"
+
+
 def __equity_base_builder(session=Session.NORMAL, duration=Duration.DAY):
     """
     Returns a base OrderBuilder for equity orders with common settings.
@@ -54,7 +67,7 @@ def equity_buy_limit(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(str(price))
+        .set_price(_price_str(price))
         .add_equity_leg(EquityInstruction.BUY, symbol, quantity)
     )
 
@@ -68,7 +81,7 @@ def equity_sell_limit(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(str(price))
+        .set_price(_price_str(price))
         .add_equity_leg(EquityInstruction.SELL, symbol, quantity)
     )
 
@@ -82,7 +95,7 @@ def equity_buy_stop(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.STOP)
-        .set_stop_price(str(stop_price))
+        .set_stop_price(_price_str(stop_price))
         .add_equity_leg(EquityInstruction.BUY, symbol, quantity)
     )
 
@@ -96,7 +109,7 @@ def equity_sell_stop(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.STOP)
-        .set_stop_price(str(stop_price))
+        .set_stop_price(_price_str(stop_price))
         .add_equity_leg(EquityInstruction.SELL, symbol, quantity)
     )
 
@@ -115,8 +128,8 @@ def equity_buy_stop_limit(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.STOP_LIMIT)
-        .set_stop_price(str(stop_price))
-        .set_price(str(limit_price))
+        .set_stop_price(_price_str(stop_price))
+        .set_price(_price_str(limit_price))
         .add_equity_leg(EquityInstruction.BUY, symbol, quantity)
     )
 
@@ -135,8 +148,8 @@ def equity_sell_stop_limit(
     return (
         __equity_base_builder(session, duration)
         .set_order_type(OrderType.STOP_LIMIT)
-        .set_stop_price(str(stop_price))
-        .set_price(str(limit_price))
+        .set_stop_price(_price_str(stop_price))
+        .set_price(_price_str(limit_price))
         .add_equity_leg(EquityInstruction.SELL, symbol, quantity)
     )
 
@@ -214,7 +227,7 @@ def option_buy_to_open_limit(
     return (
         __option_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(str(price))
+        .set_price(_price_str(price))
         .add_option_leg(OptionInstruction.BUY_TO_OPEN, symbol, quantity)
     )
 
@@ -228,7 +241,7 @@ def option_sell_to_open_limit(
     return (
         __option_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(str(price))
+        .set_price(_price_str(price))
         .add_option_leg(OptionInstruction.SELL_TO_OPEN, symbol, quantity)
     )
 
@@ -242,7 +255,7 @@ def option_buy_to_close_limit(
     return (
         __option_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(str(price))
+        .set_price(_price_str(price))
         .add_option_leg(OptionInstruction.BUY_TO_CLOSE, symbol, quantity)
     )
 
@@ -256,7 +269,7 @@ def option_sell_to_close_limit(
     return (
         __option_base_builder(session, duration)
         .set_order_type(OrderType.LIMIT)
-        .set_price(str(price))
+        .set_price(_price_str(price))
         .add_option_leg(OptionInstruction.SELL_TO_CLOSE, symbol, quantity)
     )
 

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -885,7 +885,7 @@ async def place_option_combo_order(
     # Set order type and net price
     builder = builder.set_order_type(order_type.upper())
     if price is not None:
-        builder = builder.set_price(price)  # net debit/credit as positive number
+        builder = builder.set_price(str(price))  # net debit/credit as positive number
 
     for leg in legs:
         builder = builder.add_option_leg(

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -18,6 +18,7 @@ from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
 from schwab_mcp.tools.utils import parse_date
 from schwab_mcp.tools.order_helpers import (
+    _price_str,
     equity_buy_limit,
     equity_buy_market,
     equity_buy_stop,
@@ -885,7 +886,7 @@ async def place_option_combo_order(
     # Set order type and net price
     builder = builder.set_order_type(order_type.upper())
     if price is not None:
-        builder = builder.set_price(str(price))  # net debit/credit as positive number
+        builder = builder.set_price(_price_str(price))
 
     for leg in legs:
         builder = builder.add_option_leg(

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -886,6 +886,7 @@ async def place_option_combo_order(
     # Set order type and net price
     builder = builder.set_order_type(order_type.upper())
     if price is not None:
+        # net debit/credit as positive number
         builder = builder.set_price(_price_str(price))
 
     for leg in legs:

--- a/tests/test_build_order_spec.py
+++ b/tests/test_build_order_spec.py
@@ -1,6 +1,8 @@
+import warnings
 from typing import Any, cast
 
 import pytest
+from schwab_mcp.tools.order_helpers import _price_str
 from schwab_mcp.tools.orders import (
     _build_equity_order_spec,
     _build_option_order_spec,
@@ -283,13 +285,9 @@ class TestPriceStr:
         ],
     )
     def test_matches_schwab_py_truncation(self, price, expected):
-        from schwab_mcp.tools.order_helpers import _price_str
-
         assert _price_str(price) == expected
 
     def test_building_a_limit_order_emits_no_deprecation_warning(self):
-        import warnings
-
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             spec = _build_equity_order_spec("AAPL", 10, "BUY", "LIMIT", price=904.5)

--- a/tests/test_build_order_spec.py
+++ b/tests/test_build_order_spec.py
@@ -267,3 +267,31 @@ class TestBuildTrailingStopOrderSpec:
             _build_trailing_stop_order_spec(
                 symbol, quantity, "SELL", trail_offset=bad_offset
             )
+
+
+class TestPriceStr:
+    @pytest.mark.parametrize(
+        ("price", "expected"),
+        [
+            (904.5, "904.50"),
+            (0.1 + 0.2, "0.3000"),
+            (123.456789, "123.45"),
+            (0.0001, "0.0001"),
+            (1.005, "1.00"),
+            (0.0, "0.00"),
+            (-12.349, "-12.34"),
+        ],
+    )
+    def test_matches_schwab_py_truncation(self, price, expected):
+        from schwab_mcp.tools.order_helpers import _price_str
+
+        assert _price_str(price) == expected
+
+    def test_building_a_limit_order_emits_no_deprecation_warning(self):
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            spec = _build_equity_order_spec("AAPL", 10, "BUY", "LIMIT", price=904.5)
+            built = cast(dict[str, Any], spec.build())
+        assert built["price"] == "904.50"


### PR DESCRIPTION
schwab-py deprecated float input to `set_price`/`set_stop_price`; this stops the warning and keeps the wire format byte-identical to before, by formatting prices ourselves with the same 2/4-decimal truncation schwab-py used to apply.

## What / Why

| What | Why |
|---|---|
| Cherry-pick `ratio-yolo/schwab-mcp@1a087c3` (`str(price)` at all 13 call sites) | Their fork found the deprecation first; layering on their commit keeps history aligned across the fork network |
| Replace `str()` with `_price_str()` — 2dp ≥ \$1, 4dp < \$1, truncated | `str(0.1+0.2)` is `"0.30000000000000004"` and `str(904.5)` is `"904.5"`; Schwab wants `"0.3000"` / `"904.50"`. This matches what schwab-py's `truncate_float` produced before it started warning |
| 8 new tests | Pin the formatting cases and assert building a limit order is now warning-free |

## Where things changed

```
src/schwab_mcp/tools/
  order_helpers.py   +_price_str(); 12 set_price/set_stop_price call sites
  orders.py          import _price_str; 1 call site in place_option_combo_order
tests/
  test_build_order_spec.py   +TestPriceStr (7 format cases + 1 no-warning regression)
```

## How I know it works

| Check | Result |
|---|---|
| `_price_str` vs `str` vs schwab-py's `truncate_float` on `0.1+0.2`, `904.5`, `123.456789`, `1.005` | `_price_str` matches `truncate_float` byte-for-byte |
| `warnings.simplefilter("error")` around `_build_equity_order_spec(..., price=904.5)` | passes — no deprecation fired |
| `scripts/lint` | clean |
| `uv run pytest` | 338 passed (8 new), 0 failed |

## Commits

| SHA | Author | What |
|---|---|---|
| `f5df849` | gittaylor (cherry-picked from `ratio-yolo@1a087c3`) | `set_price(price)` → `set_price(str(price))` |
| `0be0cab` | bharat | `str()` → `_price_str()`, helper, tests |