### PR TITLE
fix: address ratio-yolo audit findings H4 and M5

### DIFF
--- a/src/schwab_mcp/approvals/base.py
+++ b/src/schwab_mcp/approvals/base.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import abc
+import logging
 from dataclasses import dataclass
 from enum import Enum
 from typing import Mapping
+
+
+logger = logging.getLogger(__name__)
 
 
 class ApprovalDecision(str, Enum):
@@ -56,9 +60,22 @@ class ApprovalManager(abc.ABC):
 
 
 class NoOpApprovalManager(ApprovalManager):
-    """Approval manager that always approves requests."""
+    """Approval manager that always approves requests.
 
-    async def require(self, request: ApprovalRequest) -> ApprovalDecision:  # noqa: ARG002
+    Used when ``--jesus-take-the-wheel`` is set. Every auto-approval is logged
+    at WARNING so there is at least an audit trail in stderr/logs of which
+    write tools fired and with what (already-redacted) arguments.
+    """
+
+    async def require(self, request: ApprovalRequest) -> ApprovalDecision:
+        logger.warning(
+            "Auto-approving write tool '%s' (request=%s, approval=%s) with no "
+            "human review: %s",
+            request.tool_name,
+            request.request_id,
+            request.id,
+            dict(request.arguments),
+        )
         return ApprovalDecision.APPROVED
 
 

--- a/src/schwab_mcp/cli.py
+++ b/src/schwab_mcp/cli.py
@@ -1,4 +1,5 @@
 import click
+import logging
 import sys
 import anyio
 import os
@@ -15,6 +16,8 @@ from schwab_mcp.approvals import (
     SignalApprovalSettings,
 )
 
+
+logger = logging.getLogger(__name__)
 
 APP_NAME = "schwab-mcp"
 TOKEN_MAX_AGE_SECONDS = schwab_auth.DEFAULT_MAX_TOKEN_AGE_SECONDS
@@ -276,10 +279,11 @@ def server(
             )
             return 1
     except Exception as e:
+        logger.exception("Error initializing Schwab client")
         send_error_response(
-            f"Error initializing Schwab client: {str(e)}",
+            "Failed to initialize Schwab client; see server logs.",
             code=500,
-            details={"error": str(e)},
+            details={"error_type": type(e).__name__},
         )
         return 1
 
@@ -397,8 +401,11 @@ def server(
         anyio.run(server.run, backend="asyncio")
         return 0
     except Exception as e:
+        logger.exception("Error running server")
         send_error_response(
-            f"Error running server: {str(e)}", code=500, details={"error": str(e)}
+            "Server failed; see server logs.",
+            code=500,
+            details={"error_type": type(e).__name__},
         )
         return 1
 

--- a/src/schwab_mcp/cli.py
+++ b/src/schwab_mcp/cli.py
@@ -378,9 +378,12 @@ def server(
         else:
             approval_manager = NoOpApprovalManager()
 
-        if jesus_take_the_wheel and discord_token:
+        if jesus_take_the_wheel:
             click.echo(
-                "Warning: --jesus-take-the-wheel bypasses Discord approvals.", err=True
+                "WARNING: --jesus-take-the-wheel is set. Every write tool "
+                "(order placement, cancellation, etc.) will execute with NO "
+                "human approval.",
+                err=True,
             )
 
         server = SchwabMCPServer(

--- a/tests/test_approval_wrapping.py
+++ b/tests/test_approval_wrapping.py
@@ -15,6 +15,7 @@ from schwab_mcp.approvals import (
     ApprovalRequest,
     DiscordApprovalManager,
     DiscordApprovalSettings,
+    NoOpApprovalManager,
 )
 from schwab_mcp.context import SchwabContext, SchwabServerContext
 from schwab_mcp.tools import _registration
@@ -169,6 +170,29 @@ def test_progress_notifications_emitted_when_supported() -> None:
     assert [entry["progress"] for entry in session.progress] == [0, 1]
     assert session.progress[0]["message"].startswith("Waiting for reviewer approval")
     assert session.progress[1]["message"].startswith("Reviewer approved")
+
+
+def test_noop_manager_logs_every_auto_approval(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = NoOpApprovalManager()
+    request = ApprovalRequest(
+        id="appr-1",
+        tool_name="place_equity_order",
+        request_id="req-1",
+        client_id=None,
+        arguments={"symbol": '"NVDA"', "account_hash": '"\\u2026WXYZ"'},
+    )
+
+    with caplog.at_level("WARNING", logger="schwab_mcp.approvals.base"):
+        decision = await_result(manager.require(request))
+
+    assert decision is ApprovalDecision.APPROVED
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "WARNING"
+    assert "place_equity_order" in record.getMessage()
+    assert "req-1" in record.getMessage()
 
 
 def test_discord_manager_requires_approvers() -> None:


### PR DESCRIPTION
Two small follow-ups from cross-checking against the `ratio-yolo/schwab-mcp` security review — the only two of their findings that apply to this fork's codebase.

## What / Why

| What | Why |
|---|---|
| `NoOpApprovalManager` logs every auto-approval at WARNING | `--jesus-take-the-wheel` previously left zero record of which write tools fired or with what arguments — no audit trail at all |
| The bypass banner prints whenever `--jesus-take-the-wheel` is set | It used to print only when a Discord token was *also* configured, so a bare bypass started silently |
| `server()`'s two broad `except` blocks send a generic message + `error_type` and route the full traceback to `logger.exception` | `str(e)` from httpx/authlib/schwab-py can carry file paths or URL fragments; that doesn't belong on the MCP error channel where an LLM client reads it |

The interactive `auth` command's `click.echo(..., err=True)` is left unchanged — that's a terminal stderr message to the human running auth, not the MCP channel.

## Where things changed

```
src/schwab_mcp/approvals/base.py    +logger; NoOpApprovalManager.require() logs before APPROVED
src/schwab_mcp/cli.py               +logger; banner unconditional; 2× send_error_response → generic + logger.exception
tests/test_approval_wrapping.py     +test_noop_manager_logs_every_auto_approval
```

## How I know it works

| Check | Result |
|---|---|
| `scripts/lint` | clean |
| `uv run pytest` | 339 passed (1 new), 0 failed |
| caplog test asserts WARNING with tool name + request id | passes |

Closes #18
Closes #19