### PR TITLE
feat(approvals): link signal-cli as a secondary device (no spare number)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,9 @@ SCHWAB_CALLBACK_URL=https://127.0.0.1:8182
 # SCHWAB_BASE_URL=https://api.schwabapi.com
 
 # --- Signal approval backend --------------------------------------------------
-# Bot account the signal-cli daemon is registered as (E.164, e.g. +15555550100)
+# The number the signal-cli daemon acts as. If you used `signal-daemon link`,
+# this is YOUR number (same as APPROVERS). If you used `register`, it is the
+# bot's separate number. (E.164, e.g. +15555550199)
 SCHWAB_MCP_SIGNAL_ACCOUNT=
 # Your number — replies from this number are honoured (E.164)
 SCHWAB_MCP_SIGNAL_APPROVERS=

--- a/docs/signal-setup.md
+++ b/docs/signal-setup.md
@@ -6,54 +6,57 @@ Signal message on your phone. It talks to a local
 public inbound endpoint and trade details stay end-to-end encrypted between
 the daemon and your phone.
 
-## What you need
+There are two ways to attach the daemon to Signal. **Linking** is simpler and
+needs no extra phone number; **registering** gives the bot its own identity.
 
-| Thing | Notes |
-|---|---|
-| A second phone number | The daemon registers its **own** Signal account; it cannot share the number your phone uses. A cheap VoIP number works. |
-| `signal-cli-rest-api` running locally | Easiest is the [bbernhard/signal-cli-rest-api][rest] Docker image. |
-| Your own number | Passed as `--signal-approver`; only replies from this number are honoured. |
+## Option A — link as a device on your account (recommended)
 
-## One-time registration
+The daemon joins your existing Signal account as a secondary device, the same
+way Signal Desktop does. Approval prompts land in your **Note to Self** thread.
 
 ```bash
-# 1. Start the REST daemon (persists state in the named volume)
-docker run -d --name signal-api \
-  -p 127.0.0.1:8080:8080 \
-  -v signal-cli-data:/home/.local/share/signal-cli \
-  -e MODE=native \
-  bbernhard/signal-cli-rest-api:latest
-
-# 2. Register the bot number (replace with your VoIP number)
-curl -X POST http://127.0.0.1:8080/v1/register/+15555550100
-
-# 3. Verify with the SMS code Signal sends to that number
-curl -X POST http://127.0.0.1:8080/v1/register/+15555550100/verify/123456
+scripts/signal-daemon up
+scripts/signal-daemon link        # opens a QR — scan from your phone:
+                                  # Signal → Settings → Linked Devices → +
 ```
 
-Send yourself a test message to confirm:
-
-```bash
-curl -X POST http://127.0.0.1:8080/v2/send \
-  -H 'Content-Type: application/json' \
-  -d '{"number":"+15555550100","recipients":["+15555550199"],"message":"hello"}'
-```
-
-## Running the server with Signal approvals
+After scanning, both `--signal-account` and `--signal-approver` are **your**
+number:
 
 ```bash
 schwab-mcp server \
-  --client-id "$SCHWAB_CLIENT_ID" \
-  --client-secret "$SCHWAB_CLIENT_SECRET" \
   --signal-api-url http://127.0.0.1:8080 \
-  --signal-account +15555550100 \
+  --signal-account  +15555550199 \
   --signal-approver +15555550199
 ```
 
-When a write tool is invoked you'll receive a Signal message describing the
-tool and its arguments. **Reply to that message** (long-press → Reply) with
-`ok` to approve or `no` to deny. Anything else, or no reply within
-`--signal-timeout` seconds (default 600), is treated as a denial.
+To unlink later, remove the device from your phone's Linked Devices list.
+
+## Option B — register a separate bot number
+
+If you'd rather the bot have its own identity (and you have a spare number):
+
+```bash
+scripts/signal-daemon up
+scripts/signal-daemon register +15555550100         # Signal sends an SMS code
+scripts/signal-daemon verify   +15555550100 123456  # enter the code
+```
+
+Then `--signal-account` is the bot's number and `--signal-approver` is yours:
+
+```bash
+schwab-mcp server \
+  --signal-api-url http://127.0.0.1:8080 \
+  --signal-account  +15555550100 \
+  --signal-approver +15555550199
+```
+
+## Approving a trade
+
+When a write tool is invoked you receive a Signal message describing the tool
+and its arguments. **Reply to that message** (long-press → Reply) with `ok` to
+approve or `no` to deny. Anything else, or no reply within `--signal-timeout`
+seconds (default 600), is treated as a denial.
 
 You may not configure Discord and Signal approvals at the same time; the
 server wires exactly one approval backend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-toon>=0.1.2",
     "pyyaml>=6.0.3",
     "schwab-py",
+    "websockets>=14.0",
 ]
 
 [project.scripts]

--- a/scripts/signal-daemon
+++ b/scripts/signal-daemon
@@ -37,7 +37,7 @@ case "$cmd" in
             docker run -d --name "$CONTAINER" \
                 -p "127.0.0.1:${PORT}:8080" \
                 -v signal-cli-data:/home/.local/share/signal-cli \
-                -e MODE=native \
+                -e MODE=json-rpc \
                 bbernhard/signal-cli-rest-api:latest
         fi
         echo "signal-cli-rest-api listening on ${API}"

--- a/scripts/signal-daemon
+++ b/scripts/signal-daemon
@@ -16,7 +16,9 @@ Usage: scripts/signal-daemon <command> [args]
   up                          start the signal-cli-rest-api container (idempotent)
   down                        stop and remove it (registration data persists in the volume)
   logs                        follow daemon logs
-  register <bot-number>       begin registration; Signal sends an SMS code to that number
+  link     [device-name]      link as a secondary device on YOUR Signal account (no spare
+                              number needed) — opens a QR; scan from phone Settings > Linked Devices
+  register <bot-number>       OR claim a separate number for the bot; Signal sends an SMS code
   verify   <bot-number> <code>  complete registration with the SMS code
   send     <bot> <to> <text>  sanity-check: send <text> from <bot> to <to>
 
@@ -45,6 +47,14 @@ case "$cmd" in
         ;;
     logs)
         docker logs -f "$CONTAINER"
+        ;;
+    link)
+        name=${1:-schwab-mcp}
+        url="${API}/v1/qrcodelink?device_name=${name}"
+        echo "Open this URL and scan the QR from your phone (Signal > Settings > Linked Devices > +):"
+        echo "  ${url}"
+        command -v open >/dev/null && open "${url}" || true
+        echo "After scanning, set SCHWAB_MCP_SIGNAL_ACCOUNT and SCHWAB_MCP_SIGNAL_APPROVERS to YOUR number."
         ;;
     register)
         [ $# -eq 1 ] || { usage; exit 1; }

--- a/src/schwab_mcp/approvals/signal.py
+++ b/src/schwab_mcp/approvals/signal.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
 import httpx
+import websockets
 
 from schwab_mcp.approvals.base import (
     ApprovalDecision,
@@ -144,19 +146,19 @@ class SignalApprovalManager(ApprovalManager):
             logger.exception("Failed to post Signal notice")
 
     async def _receive_loop(self) -> None:
+        ws_url = (
+            self._settings.api_url.replace("http", "ws", 1)
+            + f"/v1/receive/{self._settings.account}"
+        )
         while True:
             try:
-                response = await self._client.get(
-                    f"/v1/receive/{self._settings.account}",
-                    params={"timeout": 30},
-                )
-                response.raise_for_status()
-                for envelope in response.json():
-                    await self._handle_envelope(envelope)
+                async with websockets.connect(ws_url) as ws:
+                    async for frame in ws:
+                        await self._handle_envelope(json.loads(frame))
             except asyncio.CancelledError:
                 raise
             except Exception:
-                logger.exception("Signal receive loop error; retrying in 5s")
+                logger.exception("Signal receive websocket error; reconnecting in 5s")
                 await asyncio.sleep(5)
 
     async def _handle_envelope(self, envelope: dict[str, Any]) -> None:

--- a/src/schwab_mcp/approvals/signal.py
+++ b/src/schwab_mcp/approvals/signal.py
@@ -162,7 +162,11 @@ class SignalApprovalManager(ApprovalManager):
     async def _handle_envelope(self, envelope: dict[str, Any]) -> None:
         env = envelope.get("envelope", envelope)
         source = env.get("sourceNumber") or env.get("source")
-        data = env.get("dataMessage") or {}
+        # In linked-device mode the approver's reply is their own outgoing
+        # message, delivered to us as syncMessage.sentMessage rather than an
+        # incoming dataMessage. Accept either shape.
+        sync = (env.get("syncMessage") or {}).get("sentMessage")
+        data = env.get("dataMessage") or sync or {}
         quote = data.get("quote") or {}
         quoted_ts = quote.get("id")
         text = (data.get("message") or "").strip().lower()

--- a/tests/test_approval_signal.py
+++ b/tests/test_approval_signal.py
@@ -100,6 +100,31 @@ def test_require_approves_on_ok_reply(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "approved" in sent[-1]
 
 
+def test_require_approves_on_sync_message_reply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Linked-device mode: the approver's reply arrives as syncMessage.sentMessage."""
+    manager, _ = _make_manager(monkeypatch)
+
+    async def scenario() -> ApprovalDecision:
+        task = asyncio.create_task(manager.require(_request()))
+        await asyncio.sleep(0)
+        (sent_ts,) = list(manager._pending)
+        await manager._handle_envelope(
+            {
+                "envelope": {
+                    "sourceNumber": "+15555550199",
+                    "syncMessage": {
+                        "sentMessage": {"message": "ok", "quote": {"id": sent_ts}}
+                    },
+                }
+            }
+        )
+        return await task
+
+    assert await_result(scenario()) is ApprovalDecision.APPROVED
+
+
 def test_require_denies_on_no_reply(monkeypatch: pytest.MonkeyPatch) -> None:
     manager, sent = _make_manager(monkeypatch)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2105,6 +2105,7 @@ dependencies = [
     { name = "python-toon" },
     { name = "pyyaml" },
     { name = "schwab-py" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -2131,6 +2132,7 @@ requires-dist = [
     { name = "python-toon", specifier = ">=0.1.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "schwab-py", git = "https://github.com/jkoelker/schwab-py.git?rev=proxy_support" },
+    { name = "websockets", specifier = ">=14.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Adds linked-device mode (no spare phone number) and the receive-path fixes that make it actually work end-to-end.

## What / Why

| What | Why |
|---|---|
| `signal-daemon link` — scan a QR to attach the daemon as a linked device on your own account | drops the second-phone-number requirement; prompts land in Note to Self |
| Daemon runs in `MODE=json-rpc` | `native`/`normal` modes shell out per request; concurrent send + receive fight over the account lock and a 30s receive poll blocks every send |
| Receive loop uses WebSocket (`websockets`, declared direct) | `/v1/receive` is WebSocket-only in json-rpc mode; the old httpx GET 400'd |
| `_handle_envelope` reads `syncMessage.sentMessage` as well as `dataMessage` | in linked mode your reply is your *own* outgoing, delivered as a sync message |
| `docs/signal-setup.md` rewritten to lead with linking | register-a-separate-number stays as Option B |

## How I know it works

| Check | Result |
|---|---|
| Live round-trip (link mode, json-rpc, WebSocket) | `Decision: approved` after a Note-to-Self reply |
| `scripts/lint` | clean |
| `uv run pytest` | 340 passed (2 new), 0 failed |

## Known caveats / follow-ups

| Item | Why deferred |
|---|---|
| json-rpc mode drains Signal eagerly; a reply that arrives while no WebSocket subscriber is connected is ACKed and dropped (bbernhard/signal-cli-rest-api#834) | fail-closed (the approval just times out → EXPIRED), so safe; hardening would be `--receive-mode=manual` once that lands in a release |