### PR TITLE
feat(auth): add --manual auth flow (cherry-pick from ratio-yolo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ info/
 # Environment files
 .env
 .env.local
+.token.yaml
+.token.json
 
 # Python
 __pycache__/

--- a/scripts/schwab-auth
+++ b/scripts/schwab-auth
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run the Schwab OAuth flow from inside the devcontainer using the manual
+# (paste-the-redirect-URL) path, so no local HTTPS listener is needed.
+# Runs on the HOST; the CLI runs in the container.
+
+set -euo pipefail
+
+# .env is bind-mounted into the container; source it there so SCHWAB_CLIENT_ID
+# and SCHWAB_CLIENT_SECRET reach click via envvar without ever appearing in argv.
+exec devcontainer exec --workspace-folder . bash -lc '
+    set -a; [ -f .env ] && source .env; set +a
+    exec uv run schwab-mcp auth --manual --token-path .token.yaml
+'

--- a/scripts/signal-server
+++ b/scripts/signal-server
@@ -7,11 +7,16 @@ set -euo pipefail
 
 : "${SCHWAB_MCP_SIGNAL_ACCOUNT:?set SCHWAB_MCP_SIGNAL_ACCOUNT to the bot E.164 number}"
 : "${SCHWAB_MCP_SIGNAL_APPROVERS:?set SCHWAB_MCP_SIGNAL_APPROVERS to your E.164 number}"
-API_URL=${SCHWAB_MCP_SIGNAL_API_URL:-http://host.docker.internal:8080}
 
-exec devcontainer exec --workspace-folder . -- \
-    uv run schwab-mcp server \
-        --signal-api-url "$API_URL" \
-        --signal-account "$SCHWAB_MCP_SIGNAL_ACCOUNT" \
-        --signal-approver "$SCHWAB_MCP_SIGNAL_APPROVERS" \
-        "$@"
+# Source .env again inside the container so SCHWAB_CLIENT_ID / _SECRET reach
+# click via envvar without ever appearing in argv. The Signal flags are not
+# secrets, so passing them on the inner argv is fine.
+exec devcontainer exec --workspace-folder . bash -lc "
+    set -a; [ -f .env ] && source .env; set +a
+    exec uv run schwab-mcp server \
+        --token-path .token.yaml \
+        --signal-api-url '${SCHWAB_MCP_SIGNAL_API_URL:-http://host.docker.internal:8080}' \
+        --signal-account '$SCHWAB_MCP_SIGNAL_ACCOUNT' \
+        --signal-approver '$SCHWAB_MCP_SIGNAL_APPROVERS' \
+        $*
+"

--- a/src/schwab_mcp/cli.py
+++ b/src/schwab_mcp/cli.py
@@ -66,12 +66,26 @@ def cli():
     default="https://api.schwabapi.com",
     help="Schwab API base URL",
 )
+@click.option(
+    "--browser",
+    type=str,
+    default=None,
+    help="Browser to use for authentication (e.g., 'safari', 'firefox'). Chrome often blocks self-signed certs.",
+)
+@click.option(
+    "--manual",
+    is_flag=True,
+    default=False,
+    help="Use manual flow - you'll paste the callback URL instead of using a local server.",
+)
 def auth(
     token_path: str,
     client_id: str | None,
     client_secret: str | None,
     callback_url: str,
     base_url: str,
+    browser: str | None,
+    manual: bool,
 ) -> int:
     """Initialize Schwab client authentication."""
     creds = tokens.load_credentials(tokens.credentials_path(APP_NAME))
@@ -86,25 +100,76 @@ def auth(
         )
         raise SystemExit(1)
 
-    click.echo(f"Initializing authentication flow to create token at: {token_path}")
+    click.echo("=" * 80)
+    click.echo("SCHWAB MCP AUTHENTICATION")
+    click.echo("=" * 80)
+    click.echo()
+    click.echo(f"Token will be saved to: {token_path}")
+    click.echo()
+    click.echo("Configuration:")
+    click.echo(f"  Client ID: {client_id[:20]}...")
+    click.echo(f"  Callback URL: {callback_url}")
+    click.echo(f"  Base URL: {base_url}")
+    click.echo()
+    click.echo(
+        "IMPORTANT: Verify these match EXACTLY with your Schwab Developer Portal:"
+    )
+    click.echo("  1. Go to: https://developer.schwab.com/dashboard")
+    click.echo("  2. Click on your app")
+    click.echo("  3. Compare the 'App Key' and 'Callback URL' values")
+    click.echo()
+    click.echo("=" * 80)
+    click.echo()
     token_manager = tokens.Manager(token_path)
 
     try:
-        # This will initiate the manual authentication flow
-        schwab_auth.easy_client(
-            client_id=client_id,
-            client_secret=client_secret,
-            callback_url=callback_url,
-            token_manager=token_manager,
-            max_token_age=TOKEN_MAX_AGE_SECONDS,
-            base_url=base_url,
-        )
+        if manual:
+            # Use manual flow - user pastes the callback URL
+            from schwab import auth as schwab_raw_auth
+
+            client = schwab_raw_auth.client_from_manual_flow(
+                api_key=client_id,
+                app_secret=client_secret,
+                callback_url=callback_url,
+                token_path=token_path,
+                asyncio=False,
+                base_url=base_url,
+            )
+
+            # Save token using our manager
+            if hasattr(client, "_session") and hasattr(client._session, "token"):
+                token_manager.write(client._session.token)
+        else:
+            # This will initiate the automatic authentication flow
+            schwab_auth.easy_client(
+                client_id=client_id,
+                client_secret=client_secret,
+                callback_url=callback_url,
+                token_manager=token_manager,
+                max_token_age=TOKEN_MAX_AGE_SECONDS,
+                base_url=base_url,
+                requested_browser=browser,
+            )
 
         # If we get here, the authentication was successful
-        click.echo(f"Authentication successful! Token saved to: {token_path}")
+        click.echo()
+        click.echo("=" * 80)
+        click.echo("✓ Authentication successful!")
+        click.echo("=" * 80)
+        click.echo(f"Token saved to: {token_path}")
         return 0
     except Exception as e:
-        click.echo(f"Authentication failed: {str(e)}", err=True)
+        click.echo()
+        click.echo("=" * 80)
+        click.echo("✗ Authentication failed")
+        click.echo("=" * 80)
+        click.echo(f"Error: {str(e)}", err=True)
+        click.echo()
+        click.echo("Common issues:")
+        click.echo("  1. Client ID or Secret doesn't match Developer Portal")
+        click.echo("  2. Callback URL doesn't match Developer Portal")
+        click.echo("  3. Callback URL was changed recently (wait until market close)")
+        click.echo("  4. Browser blocked the popup or redirect")
         return 1
 
 

--- a/src/schwab_mcp/cli.py
+++ b/src/schwab_mcp/cli.py
@@ -124,21 +124,17 @@ def auth(
 
     try:
         if manual:
-            # Use manual flow - user pastes the callback URL
             from schwab import auth as schwab_raw_auth
 
-            client = schwab_raw_auth.client_from_manual_flow(
+            schwab_raw_auth.client_from_manual_flow(
                 api_key=client_id,
                 app_secret=client_secret,
                 callback_url=callback_url,
                 token_path=token_path,
+                token_write_func=token_manager.write,
                 asyncio=False,
                 base_url=base_url,
             )
-
-            # Save token using our manager
-            if hasattr(client, "_session") and hasattr(client._session, "token"):
-                token_manager.write(client._session.token)
         else:
             # This will initiate the automatic authentication flow
             schwab_auth.easy_client(


### PR DESCRIPTION
Cherry-picks `ratio-yolo/schwab-mcp@f3f3c53` so `schwab-mcp auth --manual` prints the Schwab authorize URL and prompts you to paste back the redirect, instead of running a local HTTPS listener — which is what makes auth work from inside the devcontainer.

## What / Why

| What | Why |
|---|---|
| `auth --manual` → `client_from_manual_flow()` | no `127.0.0.1:8182` listener needed; browser runs on the host, CLI runs anywhere, you copy-paste the redirect URL between them |
| `auth --browser <name>` | their commit also lets you pick a browser for the listener flow; kept for completeness |
| Layer: `token_write_func=token_manager.write` instead of `client._session.token` | their original reached into a schwab-py private attr (pyright rejected it); the public callback does the same job |

## How I know it works

| Check | Result |
|---|---|
| `scripts/lint` | clean (0 pyright errors after the layer) |
| `uv run pytest` | 340 passed |
| `schwab-mcp auth --help` | shows `--manual` and `--browser` |

## Commits

| SHA | Author | What |
|---|---|---|
| `c789e73` | gittaylor (cherry-picked from `ratio-yolo@f3f3c53`) | `--manual` + `--browser` flags, verbose auth-URL banner |
| (this) | bharat | swap `_session` access for `token_write_func` |