### PR TITLE
fix(tools): normalize OCC option symbols + surface empty Schwab error bodies

### DIFF
--- a/src/schwab_mcp/tools/quotes.py
+++ b/src/schwab_mcp/tools/quotes.py
@@ -1,4 +1,5 @@
 #
+import re
 from collections.abc import Callable
 from typing import Annotated, Any
 
@@ -7,6 +8,26 @@ from mcp.server.fastmcp import FastMCP
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
 from schwab_mcp.tools.utils import JSONType, call
+
+
+_OPTION_RE = re.compile(r"^([A-Za-z$]+)\s+(\d{6})([PC])(\d+)$")
+
+
+def _normalize_option_symbol(symbol: str) -> str:
+    """Normalize an option symbol to OCC 21-char format.
+
+    Accepts loose forms like ``"SPX 260821P06550"`` (root + space + YYMMDD +
+    P/C + integer strike) and pads them to ``"<root:6><YYMMDD><P/C><strike*1000:08d>"``.
+    Already-correct symbols and non-option symbols pass through unchanged.
+    """
+    m = _OPTION_RE.match(symbol)
+    if not m:
+        return symbol
+    root, date, typ, strike_str = m.groups()
+    if len(strike_str) >= 8:
+        return symbol
+    strike_padded = f"{int(strike_str) * 1000:08d}"
+    return f"{root:<6}{date}{typ}{strike_padded}"
 
 
 async def get_quotes(
@@ -31,6 +52,8 @@ async def get_quotes(
 
     if isinstance(symbols, str):
         symbols = [s.strip() for s in symbols.split(",")]
+
+    symbols = [_normalize_option_symbol(s) for s in symbols]
 
     field_enums = None
     if fields:

--- a/src/schwab_mcp/tools/utils.py
+++ b/src/schwab_mcp/tools/utils.py
@@ -75,10 +75,18 @@ async def call(
     try:
         response.raise_for_status()
     except Exception as exc:
+        body = response.text
+        if not body:
+            raw = getattr(response, "content", b"")
+            body = (
+                raw.decode("utf-8", errors="replace")
+                if raw
+                else f"HTTP {response.status_code}"
+            )
         raise SchwabAPIError(
             status_code=response.status_code,
             url=response.url,
-            body=response.text,
+            body=body,
         ) from exc
 
     if response_handler is not None:

--- a/tests/test_quotes.py
+++ b/tests/test_quotes.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from schwab_mcp.tools import quotes
+from schwab_mcp.tools.quotes import _normalize_option_symbol
 
 from conftest import make_ctx, run
 
@@ -43,3 +44,32 @@ def test_get_quotes_parses_symbols_and_fields(monkeypatch, fake_call_factory):
         client.Quote.Fields.FUNDAMENTAL,
     ]
     assert kwargs["indicative"] is False
+
+
+def test_normalize_option_symbol_pads_root_and_strike():
+    assert _normalize_option_symbol("SPX 260821P06550") == "SPX   260821P06550000"
+
+
+def test_normalize_option_symbol_already_correct():
+    assert _normalize_option_symbol("SPX   260821P06550000") == "SPX   260821P06550000"
+
+
+def test_normalize_option_symbol_regular_stock():
+    assert _normalize_option_symbol("AAPL") == "AAPL"
+
+
+def test_normalize_option_symbol_short_strike():
+    assert _normalize_option_symbol("SPY 260207C500") == "SPY   260207C00500000"
+
+
+def test_get_quotes_normalizes_option_symbols(monkeypatch, fake_call_factory):
+    captured, fake_call = fake_call_factory()
+    monkeypatch.setattr(quotes, "call", fake_call)
+
+    client = DummyQuotesClient()
+    ctx = make_ctx(client)
+    result = run(quotes.get_quotes(ctx, "SPX 260821P06550"))
+
+    assert result == "ok"
+    args = captured["args"]
+    assert args == (["SPX   260821P06550000"],)


### PR DESCRIPTION
## Summary

Pick #2 of 4 in the schwab-mcp fork-network sweep. Partial cherry-pick from [`ratio-yolo/schwab-mcp@156ed09`](https://github.com/ratio-yolo/schwab-mcp/commit/156ed09).

## What / Why

| # | Change | Why |
|---|---|---|
| 1 | `tools/quotes.py` — normalize symbols like `"SPX 260821P06550"` to OCC 21-char form `"SPX   260821P06550000"` before dispatch | LLM clients often emit the loose form; Schwab rejects it. No-op for already-correct symbols and non-option tickers. |
| 2 | `tools/utils.py` — when `response.text` is empty on `raise_for_status()`, fall back to `response.content` (decoded with `errors="replace"`) or `"HTTP {status}"` | Error diagnostics were silently blank when Schwab returned an empty body. |

## What was dropped from upstream `156ed09`

The upstream commit had two more fixes that are N/A to this fork:

- **CloudSQL reconnect-on-drop in `db/_manager.py`** — no `db/` package in this fork.
- **`get_option_chain` raw-chain dump fallback** — the conditional being patched (`isinstance(ctx.db, NoOpDatabaseManager) and snapshot_id and ...`) does not exist here; this fork's `get_option_chain` returns `await call(...)` directly with no DB-backed summary path.

## Where things changed

```
src/schwab_mcp/tools/quotes.py   +_OPTION_RE, _normalize_option_symbol, applied in get_quotes
src/schwab_mcp/tools/utils.py    body fallback in call() error path
tests/test_quotes.py             +4 normalizer unit tests + 1 integration test
```

## How I know it works

| Check | Result |
|---|---|
| `scripts/lint` | clean (ruff + format + pyright) |
| `uv run pytest` | **345 passed**, 0 failed (5 new tests in test_quotes.py) |
| Pre-commit hooks | all green |

## Convergence note

If we ever merge ratio-yolo's main wholesale, git's patch-id detection should recognize the `quotes.py` and `utils.py` hunks and skip them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
