### PR TITLE
ci: bump setup-uv from v7 to v8.0.0 (Node 24 readiness)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary

Pick #4 of 4 in the schwab-mcp fork-network sweep. Partial cherry-pick from [`jmccarrell/schwab-mcp@9813cf7`](https://github.com/jmccarrell/schwab-mcp/commit/9813cf7) ("Upgrade GitHub Actions to Node 24").

## What / Why

| Change | Why |
|---|---|
| `.github/workflows/ci.yml`: `astral-sh/setup-uv@v7` → `@v8.0.0` | Node 20 actions are deprecated; GitHub forces Node 24 starting **2026-06-02**. The v7 of `setup-uv` is Node-20-based; v8 ships on Node 24. |

## What was dropped from upstream `9813cf7`

- **`agent.yaml` updates** — that workflow was removed in PR #10, so its `setup-uv` and `create-github-app-token` bumps are N/A.
- **`container.yml` Docker action bumps** (`setup-buildx` v3→v4, `login` v3→v4, `metadata` v5→v6, `build-push` v6→v7) — already on the target versions, SHA-pinned via Renovate after PR #11. No change needed.

So this PR is just a 1-line bump.

## Test plan

- [x] CI on this PR exercises the new `setup-uv@v8.0.0` across all 5 Python matrix entries (3.10–3.14)
- [x] No code changes, no test changes
- [x] Renovate continues to pin/bump going forward; we can convert this to a SHA pin in a follow-up if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)
