### PR TITLE
chore(deps): tighten supply-chain aging gate to 14 days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,5 +75,11 @@ venv = ".venv"
 reportMissingImports = false
 typeCheckingMode = "basic"
 
+[tool.uv]
+# Supply-chain hygiene: refuse to resolve any package version less than 14 days
+# old. Mirrors `minimumReleaseAge` in renovate.json so local/CI `uv lock`
+# respects the same gate as PR creation.
+exclude-newer = "14 days"
+
 [tool.uv.sources]
 schwab-py = { git = "https://github.com/jkoelker/schwab-py.git", rev = "proxy_support" }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "docker:pinDigests"
   ],
   "labels": ["dependencies"],
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 9am on wednesday"]


### PR DESCRIPTION
## Summary
- Bump renovate.jsons `minimumReleaseAge` from 7 to 14 days so Renovate refuses to open PRs for versions less than 2 weeks old.
- Add `[tool.uv] exclude-newer = "14 days"` to pyproject.toml so local/CI `uv lock` resolutions enforce the same gate (defense in depth — Renovate gates PR creation, uv gates the resolver itself).

## Why
Increasing prevalence of supply-chain attacks against package registries. Compromised releases are usually caught and yanked within days; aged versions are dramatically safer. This is a small latency cost for a meaningful surface-area reduction.

## Test plan
- `uv lock --dry-run` (or equivalent) should now decline candidates younger than 14 days.
- Renovate dashboard will show held PRs once it re-evaluates.

Both keys are documented:
- [Renovate `minimumReleaseAge`](https://docs.renovatebot.com/key-concepts/minimum-release-age/)
- [uv `exclude-newer`](https://docs.astral.sh/uv/concepts/resolution/) (relative durations since uv 0.9.17)
