### PR TITLE
feat(tools): range-based, chunked option-order fishing campaigns

### DIFF
--- a/src/schwab_mcp/approvals/signal.py
+++ b/src/schwab_mcp/approvals/signal.py
@@ -396,6 +396,58 @@ def _render_place_equity_order(
     )
 
 
+def _parse_occ_symbol(symbol: str) -> tuple[str, str, str, str] | None:
+    """Parse an OCC option symbol into (underlying, expiry MM/DD/YYYY, C|P, strike).
+
+    OCC format: 6-char underlying (space-padded) + YYMMDD + C/P + 8-digit strike
+    (strike × 1000). Returns None if the symbol doesn't match.
+    """
+    if not isinstance(symbol, str) or len(symbol) < 16:
+        return None
+    underlying = symbol[0:6].strip()
+    yy, mm, dd = symbol[6:8], symbol[8:10], symbol[10:12]
+    cp = symbol[12:13].upper()
+    strike_raw = symbol[13:]
+    if not (
+        underlying
+        and yy.isdigit()
+        and mm.isdigit()
+        and dd.isdigit()
+        and cp in ("C", "P")
+        and strike_raw.isdigit()
+    ):
+        return None
+    expiry = f"{mm}/{dd}/20{yy}"
+    strike_val = int(strike_raw) / 1000
+    strike = f"${strike_val:,.2f}" if strike_val % 1 else f"${strike_val:,.0f}"
+    return underlying, expiry, cp, strike
+
+
+def _render_place_option_order(
+    args: Mapping[str, Any], account_names: Mapping[str, str]
+) -> str:
+    raw_instruction = str(args.get("instruction") or "").upper()
+    instruction = raw_instruction.lower().replace("_", " ") or "trade"
+    qty = args.get("quantity") or "?"
+    symbol = str(args.get("symbol") or "?")
+    account = _account_label(args.get("account_hash"), account_names)
+    descriptor = _order_descriptor(args)
+
+    parsed = _parse_occ_symbol(symbol)
+    if parsed is not None:
+        underlying, expiry, cp, strike = parsed
+        kind = "Call" if cp == "C" else "Put"
+        contract_word = "contract" if qty == 1 else "contracts"
+        body = (
+            f"{instruction} {qty} {underlying} {expiry} {strike} {kind} {contract_word}"
+        )
+    else:
+        # Fallback: use the raw symbol if it's not OCC-formatted.
+        body = f"{instruction} {qty} {symbol}"
+
+    return f"{_AGENT_NAME} wants to {body} in {account}. {descriptor}"
+
+
 def _render_cancel_order(
     args: Mapping[str, Any], account_names: Mapping[str, str]
 ) -> str:
@@ -404,9 +456,84 @@ def _render_cancel_order(
     return f"{_AGENT_NAME} wants to cancel order {order_id} in {account}."
 
 
+def _render_place_option_order_with_fishing(
+    args: Mapping[str, Any], account_names: Mapping[str, str]
+) -> str:
+    raw_instruction = str(args.get("instruction") or "").upper()
+    instruction = raw_instruction.lower().replace("_", " ") or "trade"
+    qty = args.get("quantity") or "?"
+    symbol = str(args.get("symbol") or "?")
+    account = _account_label(args.get("account_hash"), account_names)
+
+    range_start = _format_money(args.get("range_start"))
+    range_end = _format_money(args.get("range_end"))
+    step = _format_money(args.get("step"))
+
+    parsed = _parse_occ_symbol(symbol)
+    if parsed is not None:
+        underlying, expiry, cp, strike = parsed
+        kind = "Call" if cp == "C" else "Put"
+        contract_word = "contract" if qty == 1 else "contracts"
+        contract_desc = f"{underlying} {expiry} {strike} {kind} {contract_word}"
+    else:
+        contract_desc = f"option {symbol}"
+
+    chunks = args.get("chunks")
+    if isinstance(chunks, list) and chunks:
+        chunks_desc = f"chunks {'/'.join(str(c) for c in chunks)}"
+    else:
+        chunks_desc = "auto-chunked"
+
+    pattern = str(args.get("pattern") or "random_walk")
+    step_interval = args.get("step_interval_seconds")
+    jitter = args.get("timing_jitter_pct")
+
+    timing_parts = []
+    if step_interval is not None:
+        try:
+            timing_parts.append(f"~{int(float(step_interval))}s interval")
+        except (TypeError, ValueError):
+            pass
+    if jitter is not None:
+        try:
+            jitter_pct = int(round(float(jitter) * 100))
+            if jitter_pct > 0:
+                timing_parts.append(f"±{jitter_pct}% jitter")
+        except (TypeError, ValueError):
+            pass
+    timing_desc = ", ".join(timing_parts) if timing_parts else ""
+
+    range_desc_parts = [f"fishing {range_start or '?'} → {range_end or '?'}"]
+    if step:
+        range_desc_parts.append(f"step {step}")
+    range_desc_parts.append(chunks_desc)
+    range_desc_parts.append(f"pattern: {pattern}")
+    if timing_desc:
+        range_desc_parts.append(timing_desc)
+
+    range_descriptor = "(" + ", ".join(range_desc_parts) + ")"
+
+    return (
+        f"{_AGENT_NAME} wants to {instruction} {qty} {contract_desc} in "
+        f"{account}. {range_descriptor}. One approval covers the whole campaign — "
+        f"auto-adjusts within range."
+    )
+
+
+def _render_cancel_fishing(
+    args: Mapping[str, Any], account_names: Mapping[str, str]
+) -> str:
+    _ = account_names  # unused
+    campaign_id = args.get("campaign_id") or "?"
+    return f"{_AGENT_NAME} wants to cancel fishing campaign {campaign_id} (stops loop + cancels any open sub-orders)."
+
+
 _TOOL_RENDERERS: Mapping[str, Any] = {
     "place_equity_order": _render_place_equity_order,
+    "place_option_order": _render_place_option_order,
+    "place_option_order_with_fishing": _render_place_option_order_with_fishing,
     "cancel_order": _render_cancel_order,
+    "cancel_fishing": _render_cancel_fishing,
 }
 
 

--- a/src/schwab_mcp/tools/__init__.py
+++ b/src/schwab_mcp/tools/__init__.py
@@ -9,6 +9,7 @@ from mcp.server.fastmcp import FastMCP
 from schwab.client import AsyncClient
 
 from schwab_mcp.tools import account as _account
+from schwab_mcp.tools import fishing as _fishing
 from schwab_mcp.tools import history as _history
 from schwab_mcp.tools import options as _options
 from schwab_mcp.tools import orders as _orders
@@ -27,6 +28,7 @@ _TOOL_MODULES = (
     _orders,
     _quotes,
     _txns,
+    _fishing,
 )
 
 

--- a/src/schwab_mcp/tools/fishing.py
+++ b/src/schwab_mcp/tools/fishing.py
@@ -1,0 +1,864 @@
+"""Range-based, chunked option-order fishing campaigns.
+
+A "fishing" campaign places multiple LIMIT child orders ("chunks") across a
+price range and then cancel/replaces them periodically toward the range's
+terminal price, with optional randomized timing and price-walk patterns. The
+goal is to harvest the best fill within a user-approved price range without
+revealing the persistent intent of a single trader.
+
+One Signal/Discord approval at submission covers the whole campaign. Subsequent
+child cancel/place operations run autonomously inside the MCP server's event
+loop. Campaigns are tracked in an in-memory registry and die with the server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Annotated, Any, cast
+
+from mcp.server.fastmcp import FastMCP
+
+from schwab_mcp.context import SchwabContext
+from schwab_mcp.tools._registration import register_tool
+from schwab_mcp.tools.orders import _apply_order_settings, _build_option_order_spec
+from schwab_mcp.tools.utils import JSONType, call
+
+logger = logging.getLogger(__name__)
+
+
+# ----- Constants -----
+
+PATTERN_LINEAR = "linear"
+PATTERN_RANDOM_WALK = "random_walk"
+PATTERN_STAGGERED = "staggered"
+_PATTERNS = frozenset({PATTERN_LINEAR, PATTERN_RANDOM_WALK, PATTERN_STAGGERED})
+
+STATUS_RUNNING = "RUNNING"
+STATUS_FILLED = "FILLED"
+STATUS_CANCELED = "CANCELED"
+STATUS_FAILED = "FAILED"
+STATUS_EXHAUSTED = "EXHAUSTED"
+
+_OPTION_INSTRUCTIONS = frozenset(
+    {"BUY_TO_OPEN", "SELL_TO_OPEN", "BUY_TO_CLOSE", "SELL_TO_CLOSE"}
+)
+
+_DEFAULT_STEP = 0.05
+_DEFAULT_INTERVAL_SEC = 300.0
+_DEFAULT_JITTER_PCT = 0.4
+_MIN_INTERVAL_SEC = 30.0
+_MAX_CAMPAIGN_SECONDS = 60 * 60 * 4  # 4 hours hard cap
+_CANCEL_GRACE_SECONDS = 10
+
+
+@dataclass
+class _SubOrder:
+    """State for one chunk's current order."""
+
+    chunk_idx: int
+    quantity: int
+    price: float
+    order_id: str | None = None
+    schwab_status: str = "PENDING"
+    filled_quantity: int = 0
+    history: list[dict[str, Any]] = field(default_factory=list)
+
+    def is_terminal(self) -> bool:
+        return self.schwab_status in {"FILLED", "CANCELED", "REJECTED", "EXPIRED"}
+
+    def is_working(self) -> bool:
+        return self.schwab_status == "WORKING"
+
+
+@dataclass
+class _Campaign:
+    """In-memory state for one fishing campaign."""
+
+    id: str
+    account_hash: str
+    symbol: str
+    instruction: str
+    quantity: int
+    chunks: list[int]
+    range_start: float
+    range_end: float
+    step: float
+    pattern: str
+    step_interval_seconds: float
+    timing_jitter_pct: float
+    session: str
+    duration: str
+    started_at: datetime
+    status: str
+    sub_orders: list[_SubOrder] = field(default_factory=list)
+    last_event: str | None = None
+    task: asyncio.Task[None] | None = None
+    rng: random.Random = field(default_factory=random.Random)
+
+    def is_sell(self) -> bool:
+        return self.instruction.startswith("SELL")
+
+    def to_status_dict(self) -> dict[str, Any]:
+        total_filled = sum(s.filled_quantity for s in self.sub_orders)
+        return {
+            "id": self.id,
+            "status": self.status,
+            "account_hash_suffix": self.account_hash[-4:],
+            "symbol": self.symbol,
+            "instruction": self.instruction,
+            "quantity": self.quantity,
+            "filled_quantity_total": total_filled,
+            "chunks": list(self.chunks),
+            "range_start": self.range_start,
+            "range_end": self.range_end,
+            "step": self.step,
+            "pattern": self.pattern,
+            "step_interval_seconds": self.step_interval_seconds,
+            "timing_jitter_pct": self.timing_jitter_pct,
+            "session": self.session,
+            "duration": self.duration,
+            "started_at": self.started_at.isoformat(),
+            "last_event": self.last_event,
+            "sub_orders": [
+                {
+                    "chunk_idx": s.chunk_idx,
+                    "quantity": s.quantity,
+                    "price": s.price,
+                    "order_id": s.order_id,
+                    "schwab_status": s.schwab_status,
+                    "filled_quantity": s.filled_quantity,
+                    "history_count": len(s.history),
+                }
+                for s in self.sub_orders
+            ],
+        }
+
+
+# Module-level registry. In-memory only; dies with the server process.
+_CAMPAIGNS: dict[str, _Campaign] = {}
+_CAMPAIGNS_LOCK = asyncio.Lock()
+
+
+# ===== Input validation =====
+
+
+def _auto_chunks(quantity: int) -> list[int]:
+    """Auto-split a total quantity into 2-4 chunks, near-evenly."""
+    n = min(4, max(2, quantity // 3 or 1))
+    if quantity < n:
+        n = quantity
+    if n <= 0:
+        return [quantity]
+    base = quantity // n
+    rem = quantity % n
+    chunks = [base + (1 if i < rem else 0) for i in range(n)]
+    return [c for c in chunks if c > 0]
+
+
+def _validate_inputs(
+    instruction: str,
+    quantity: int,
+    range_start: float,
+    range_end: float,
+    step: float,
+    pattern: str,
+    chunks: list[int] | None,
+    step_interval_seconds: float,
+    timing_jitter_pct: float,
+) -> tuple[str, list[int], str]:
+    instruction = instruction.upper()
+    if instruction not in _OPTION_INSTRUCTIONS:
+        raise ValueError(
+            f"instruction must be one of {sorted(_OPTION_INSTRUCTIONS)}; got {instruction!r}"
+        )
+
+    is_sell = instruction.startswith("SELL")
+    if is_sell and not (range_start > range_end):
+        raise ValueError(
+            f"For SELL: range_start ({range_start}) must be > range_end ({range_end})"
+        )
+    if (not is_sell) and not (range_start < range_end):
+        raise ValueError(
+            f"For BUY: range_start ({range_start}) must be < range_end ({range_end})"
+        )
+
+    if quantity <= 0:
+        raise ValueError("quantity must be > 0")
+    if step <= 0:
+        raise ValueError("step must be > 0")
+    if abs(range_start - range_end) < step:
+        raise ValueError(
+            f"range span ({abs(range_start - range_end):.4f}) is smaller than step ({step})"
+        )
+
+    pattern_normalized = pattern.lower()
+    if pattern_normalized not in _PATTERNS:
+        raise ValueError(f"pattern must be one of {sorted(_PATTERNS)}; got {pattern!r}")
+
+    if step_interval_seconds < _MIN_INTERVAL_SEC:
+        raise ValueError(
+            f"step_interval_seconds must be >= {_MIN_INTERVAL_SEC}; got {step_interval_seconds}"
+        )
+    if not (0.0 <= timing_jitter_pct <= 1.0):
+        raise ValueError(
+            f"timing_jitter_pct must be in [0, 1]; got {timing_jitter_pct}"
+        )
+
+    if chunks is None:
+        chunks_resolved = _auto_chunks(quantity)
+    else:
+        if not chunks:
+            raise ValueError("chunks must be non-empty if provided")
+        if any(c <= 0 for c in chunks):
+            raise ValueError("each chunk must be > 0")
+        if sum(chunks) != quantity:
+            raise ValueError(f"sum(chunks)={sum(chunks)} != quantity={quantity}")
+        chunks_resolved = list(chunks)
+
+    return instruction, chunks_resolved, pattern_normalized
+
+
+# ===== Price-pattern logic =====
+
+
+def _initial_prices(campaign: _Campaign) -> list[float]:
+    """Initial limit prices for each chunk."""
+    n = len(campaign.chunks)
+    if n == 0:
+        return []
+
+    if campaign.pattern == PATTERN_LINEAR:
+        return [campaign.range_start] * n
+
+    if campaign.pattern == PATTERN_STAGGERED:
+        # Linear ladder over ~40% of the range, so all chunks start in the
+        # "favorable half" of the range.
+        span = campaign.range_start - campaign.range_end
+        prices = [
+            campaign.range_start - (span * i / max(n - 1, 1)) * 0.4 for i in range(n)
+        ]
+        # Clamp to range
+        if campaign.is_sell():
+            prices = [max(p, campaign.range_end) for p in prices]
+        else:
+            prices = [min(p, campaign.range_end) for p in prices]
+        return [round(p, 2) for p in prices]
+
+    # random_walk: scatter near range_start with up to ~3 steps of noise
+    prices: list[float] = []
+    for _ in range(n):
+        jitter_steps = campaign.rng.uniform(0, 3)
+        jitter = jitter_steps * campaign.step
+        if campaign.is_sell():
+            p = campaign.range_start - jitter
+            p = max(p, campaign.range_end)
+        else:
+            p = campaign.range_start + jitter
+            p = min(p, campaign.range_end)
+        prices.append(round(p, 2))
+    return prices
+
+
+def _next_price(campaign: _Campaign, sub: _SubOrder) -> float | None:
+    """Compute next adjusted price for a sub-order, or None if at range_end."""
+    is_sell = campaign.is_sell()
+    cur = sub.price
+    end = campaign.range_end
+    step = campaign.step
+
+    # Already at/past floor?
+    if is_sell and cur <= end:
+        return None
+    if (not is_sell) and cur >= end:
+        return None
+
+    if campaign.pattern == PATTERN_LINEAR or campaign.pattern == PATTERN_STAGGERED:
+        nxt = cur - step if is_sell else cur + step
+    else:
+        # random_walk: bias toward end (75%), stay (20%), head-fake (5%)
+        r = campaign.rng.random()
+        if r < 0.75:
+            base = cur - step if is_sell else cur + step
+            # Random step magnitude 50%-150% of base step
+            scale = 0.5 + campaign.rng.random()
+            delta = (base - cur) * scale
+            nxt = cur + delta
+        elif r < 0.95:
+            nxt = cur
+        else:
+            # head-fake — step BACK toward range_start by a fraction of step
+            nxt = cur + step * 0.5 if is_sell else cur - step * 0.5
+
+    # Clamp to range
+    if is_sell:
+        nxt = max(nxt, end)
+    else:
+        nxt = min(nxt, end)
+
+    return round(nxt, 2)
+
+
+def _select_subs_to_adjust(campaign: _Campaign) -> list[_SubOrder]:
+    """Pick which sub-orders to adjust this tick."""
+    candidates = [s for s in campaign.sub_orders if not s.is_terminal()]
+    if not candidates:
+        return []
+    if campaign.pattern == PATTERN_LINEAR:
+        return candidates
+    if len(candidates) == 1:
+        return candidates
+    # random_walk / staggered: pick 1-2
+    n = campaign.rng.choice([1, 1, 2])
+    n = min(n, len(candidates))
+    return campaign.rng.sample(candidates, n)
+
+
+def _jittered_interval(campaign: _Campaign) -> float:
+    base = campaign.step_interval_seconds
+    j = campaign.timing_jitter_pct
+    if j <= 0:
+        return base
+    factor = 1.0 + campaign.rng.uniform(-j, j)
+    return max(_MIN_INTERVAL_SEC, base * factor)
+
+
+# ===== Direct schwab client ops (no approval wrapper) =====
+
+
+def _make_response_handler(
+    client: Any, account_hash: str
+) -> Callable[[Any], tuple[bool, Any]]:
+    """Build a response handler that extracts the order_id from a Schwab response."""
+    from schwab.utils import (
+        AccountHashMismatchException,
+        UnsuccessfulOrderException,
+        Utils as SchwabUtils,
+    )
+
+    utils = SchwabUtils(client, account_hash)
+
+    def handler(response: Any) -> tuple[bool, Any]:
+        headers = getattr(response, "headers", {})
+        location = headers.get("Location") if headers else None
+        try:
+            order_id = utils.extract_order_id(response)
+        except (AccountHashMismatchException, UnsuccessfulOrderException):
+            order_id = None
+        if order_id is None and location is None:
+            return False, None
+        payload: dict[str, Any] = {}
+        if order_id is not None:
+            payload["orderId"] = str(order_id)
+            payload["accountHash"] = account_hash
+        if location is not None:
+            payload["location"] = location
+        return True, payload
+
+    return handler
+
+
+async def _direct_place_option(
+    client: Any,
+    account_hash: str,
+    symbol: str,
+    quantity: int,
+    instruction: str,
+    price: float,
+    session: str,
+    duration: str,
+    response_handler: Callable[[Any], tuple[bool, Any]],
+) -> str | None:
+    spec_builder = _build_option_order_spec(
+        symbol, quantity, instruction, "LIMIT", price=price
+    )
+    spec_builder = _apply_order_settings(spec_builder, session, duration)
+    spec = cast(dict[str, Any], spec_builder.build())
+    result = await call(
+        client.place_order,
+        account_hash=account_hash,
+        order_spec=spec,
+        response_handler=response_handler,
+    )
+    if isinstance(result, dict):
+        oid = result.get("orderId")
+        return str(oid) if oid is not None else None
+    return None
+
+
+async def _direct_cancel(client: Any, account_hash: str, order_id: str) -> None:
+    try:
+        await call(client.cancel_order, order_id=order_id, account_hash=account_hash)
+    except Exception:  # pragma: no cover - best-effort cancel
+        logger.exception("Fishing: failed to cancel order %s", order_id)
+
+
+async def _direct_get_status(
+    client: Any, account_hash: str, order_id: str
+) -> dict[str, Any] | None:
+    try:
+        result = await call(
+            client.get_order, order_id=order_id, account_hash=account_hash
+        )
+        if isinstance(result, dict):
+            return result
+    except Exception:  # pragma: no cover - best-effort poll
+        logger.exception("Fishing: failed to poll order %s", order_id)
+    return None
+
+
+# ===== Background loop =====
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def _place_initial_chunks(client: Any, campaign: _Campaign) -> None:
+    rh = _make_response_handler(client, campaign.account_hash)
+    initial_prices = _initial_prices(campaign)
+    for chunk_idx, (qty, price) in enumerate(zip(campaign.chunks, initial_prices)):
+        sub = _SubOrder(chunk_idx=chunk_idx, quantity=qty, price=price)
+        campaign.sub_orders.append(sub)
+        try:
+            oid = await _direct_place_option(
+                client,
+                campaign.account_hash,
+                campaign.symbol,
+                qty,
+                campaign.instruction,
+                price,
+                campaign.session,
+                campaign.duration,
+                rh,
+            )
+            sub.order_id = oid
+            sub.schwab_status = "WORKING" if oid else "FAILED"
+            sub.history.append(
+                {
+                    "at": _now_iso(),
+                    "event": "placed",
+                    "price": price,
+                    "order_id": oid,
+                }
+            )
+        except Exception as e:
+            sub.schwab_status = "FAILED"
+            sub.history.append(
+                {"at": _now_iso(), "event": "place_failed", "error": str(e)}
+            )
+            logger.exception(
+                "Fishing %s chunk %d initial place failed", campaign.id, chunk_idx
+            )
+
+
+async def _poll_sub_statuses(client: Any, campaign: _Campaign) -> None:
+    for sub in campaign.sub_orders:
+        if sub.is_terminal() or sub.order_id is None:
+            continue
+        status_result = await _direct_get_status(
+            client, campaign.account_hash, sub.order_id
+        )
+        if status_result is None:
+            continue
+        new_status = str(status_result.get("status", sub.schwab_status))
+        try:
+            filled = int(float(status_result.get("filledQuantity", 0)))
+        except (TypeError, ValueError):
+            filled = 0
+        if new_status != sub.schwab_status or filled != sub.filled_quantity:
+            sub.history.append(
+                {
+                    "at": _now_iso(),
+                    "event": "status_update",
+                    "old_status": sub.schwab_status,
+                    "new_status": new_status,
+                    "filled_qty": filled,
+                }
+            )
+            sub.schwab_status = new_status
+            sub.filled_quantity = filled
+
+
+def _check_terminal(campaign: _Campaign) -> bool:
+    """Returns True if the campaign reached a terminal state; mutates campaign.status."""
+    if all(s.is_terminal() for s in campaign.sub_orders):
+        total_filled = sum(s.filled_quantity for s in campaign.sub_orders)
+        any_filled = any(s.schwab_status == "FILLED" for s in campaign.sub_orders)
+        if total_filled >= campaign.quantity:
+            campaign.status = STATUS_FILLED
+            campaign.last_event = f"all chunks filled (total {total_filled})"
+        elif any_filled:
+            campaign.status = STATUS_FILLED
+            campaign.last_event = f"all chunks terminal, partial fill ({total_filled}/{campaign.quantity})"
+        else:
+            campaign.status = STATUS_EXHAUSTED
+            campaign.last_event = "all chunks terminal with no fills"
+        return True
+    return False
+
+
+async def _adjust_subs(client: Any, campaign: _Campaign) -> int:
+    """Cancel + re-place selected sub-orders. Returns count adjusted."""
+    adjustable = [s for s in campaign.sub_orders if not s.is_terminal()]
+    if not adjustable:
+        return 0
+
+    # All live subs at the floor?
+    at_floor = [s for s in adjustable if _next_price(campaign, s) is None]
+    if len(at_floor) == len(adjustable):
+        campaign.status = STATUS_EXHAUSTED
+        campaign.last_event = "all live chunks at range_end with no fill"
+        return 0
+
+    rh = _make_response_handler(client, campaign.account_hash)
+    to_adjust = _select_subs_to_adjust(campaign)
+    count = 0
+    for sub in to_adjust:
+        new_price = _next_price(campaign, sub)
+        if new_price is None or new_price == sub.price:
+            continue
+        old_oid = sub.order_id
+        if old_oid is not None:
+            await _direct_cancel(client, campaign.account_hash, old_oid)
+            sub.history.append(
+                {
+                    "at": _now_iso(),
+                    "event": "canceled_for_replace",
+                    "order_id": old_oid,
+                    "old_price": sub.price,
+                }
+            )
+        try:
+            new_oid = await _direct_place_option(
+                client,
+                campaign.account_hash,
+                campaign.symbol,
+                sub.quantity,
+                campaign.instruction,
+                new_price,
+                campaign.session,
+                campaign.duration,
+                rh,
+            )
+            sub.order_id = new_oid
+            sub.price = new_price
+            sub.schwab_status = "WORKING" if new_oid else "FAILED"
+            sub.history.append(
+                {
+                    "at": _now_iso(),
+                    "event": "replaced",
+                    "price": new_price,
+                    "order_id": new_oid,
+                }
+            )
+            count += 1
+        except Exception as e:
+            sub.schwab_status = "FAILED"
+            sub.history.append(
+                {"at": _now_iso(), "event": "replace_failed", "error": str(e)}
+            )
+            logger.exception(
+                "Fishing %s chunk %d replace failed", campaign.id, sub.chunk_idx
+            )
+    return count
+
+
+async def _cleanup_open_orders(client: Any, campaign: _Campaign) -> None:
+    for sub in campaign.sub_orders:
+        if sub.is_working() and sub.order_id is not None:
+            await _direct_cancel(client, campaign.account_hash, sub.order_id)
+            sub.schwab_status = "CANCELED"
+            sub.history.append({"at": _now_iso(), "event": "canceled_at_termination"})
+
+
+async def _run_campaign(client: Any, campaign: _Campaign) -> None:
+    """Background task: place initial chunks, then poll + adjust until terminal."""
+    logger.info("Fishing campaign %s starting", campaign.id)
+    try:
+        await _place_initial_chunks(client, campaign)
+        campaign.last_event = "initial orders placed"
+
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + _MAX_CAMPAIGN_SECONDS
+
+        while campaign.status == STATUS_RUNNING:
+            if loop.time() > deadline:
+                campaign.last_event = "max campaign duration reached"
+                campaign.status = STATUS_EXHAUSTED
+                break
+
+            sleep_secs = _jittered_interval(campaign)
+            try:
+                await asyncio.sleep(sleep_secs)
+            except asyncio.CancelledError:
+                campaign.last_event = "task canceled"
+                campaign.status = STATUS_CANCELED
+                break
+
+            await _poll_sub_statuses(client, campaign)
+            if _check_terminal(campaign):
+                break
+
+            adjusted = await _adjust_subs(client, campaign)
+            if campaign.status != STATUS_RUNNING:
+                break
+            campaign.last_event = (
+                f"poll cycle complete; adjusted {adjusted} chunk(s) @ {_now_iso()}"
+            )
+
+        await _cleanup_open_orders(client, campaign)
+    except Exception:
+        logger.exception("Fishing campaign %s crashed", campaign.id)
+        campaign.status = STATUS_FAILED
+        campaign.last_event = "campaign crashed; see server logs"
+        try:
+            await _cleanup_open_orders(client, campaign)
+        except Exception:
+            logger.exception(
+                "Fishing campaign %s: cleanup after crash also failed", campaign.id
+            )
+    finally:
+        logger.info(
+            "Fishing campaign %s ended with status %s", campaign.id, campaign.status
+        )
+
+
+# ===== Public tools =====
+
+
+async def place_option_order_with_fishing(
+    ctx: SchwabContext,
+    account_hash: Annotated[str, "Account hash for the Schwab account"],
+    symbol: Annotated[str, "Option symbol (OCC format, e.g. 'COIN  260717C00250000')"],
+    quantity: Annotated[int, "Total number of contracts across all chunks combined"],
+    instruction: Annotated[
+        str,
+        "Option instruction: BUY_TO_OPEN, SELL_TO_OPEN, BUY_TO_CLOSE, or SELL_TO_CLOSE",
+    ],
+    range_start: Annotated[
+        float,
+        "Initial (most favorable) limit price. For SELL > range_end; for BUY < range_end.",
+    ],
+    range_end: Annotated[
+        float,
+        "Terminal (least favorable) limit price. The campaign stops adjusting past this.",
+    ],
+    step: Annotated[
+        float | None, "Price step per adjustment (default 0.05)"
+    ] = _DEFAULT_STEP,
+    pattern: Annotated[
+        str | None,
+        "Step pattern: 'random_walk' (default, randomized + head-fakes), 'linear' (all chunks step together), or 'staggered' (initial ladder).",
+    ] = PATTERN_RANDOM_WALK,
+    chunks: Annotated[
+        list[int] | None,
+        "Optional chunk sizes summing to quantity (e.g. [3,2,2,1] for total=8). Default auto-splits into 2-4 chunks.",
+    ] = None,
+    step_interval_seconds: Annotated[
+        float | None,
+        f"Base seconds between adjustments (default {int(_DEFAULT_INTERVAL_SEC)}; min {int(_MIN_INTERVAL_SEC)}).",
+    ] = _DEFAULT_INTERVAL_SEC,
+    timing_jitter_pct: Annotated[
+        float | None,
+        "±jitter on interval as a fraction (0.0-1.0; default 0.4 ≈ ±40%). 0 = perfectly metronomic.",
+    ] = _DEFAULT_JITTER_PCT,
+    session: Annotated[
+        str | None, "Trading session: NORMAL (default), AM, PM, or SEAMLESS"
+    ] = "NORMAL",
+    duration: Annotated[
+        str | None, "Order duration: DAY (default), GOOD_TILL_CANCEL"
+    ] = "DAY",
+) -> JSONType:
+    """
+    Place a chunked, range-fishing option campaign with a single approval.
+
+    The campaign places multiple LIMIT child orders ("chunks") across a price
+    range, then cancel/replaces them periodically toward range_end with
+    randomized timing and price-walk patterns to obfuscate the single-trader
+    intent. ONE approval at submission covers the whole campaign — subsequent
+    child cancel/place operations run autonomously.
+
+    Returns a campaign descriptor including campaign_id. Poll get_fishing_status
+    or abort via cancel_fishing.
+
+    Params:
+    - account_hash, symbol (OCC), quantity, instruction (BUY_TO_*/SELL_TO_*).
+    - range_start (most favorable price), range_end (terminal stop price).
+    - step: price increment (default 0.05).
+    - pattern: random_walk (default), linear, staggered.
+    - chunks: optional list of chunk sizes summing to quantity (default auto 2-4).
+    - step_interval_seconds: base seconds between adjustments (default 300).
+    - timing_jitter_pct: 0.0-1.0; randomizes interval (default 0.4 = ±40%).
+
+    Background task runs in the MCP server's event loop; dies on server restart
+    (leftover orders are NOT auto-canceled on crash). 4-hour hard cap per
+    campaign.
+
+    *Write operation.* Approval required.
+    """
+    instr, chunks_resolved, pattern_resolved = _validate_inputs(
+        instruction,
+        quantity,
+        float(range_start),
+        float(range_end),
+        float(step if step is not None else _DEFAULT_STEP),
+        pattern or PATTERN_RANDOM_WALK,
+        chunks,
+        float(
+            step_interval_seconds
+            if step_interval_seconds is not None
+            else _DEFAULT_INTERVAL_SEC
+        ),
+        float(
+            timing_jitter_pct if timing_jitter_pct is not None else _DEFAULT_JITTER_PCT
+        ),
+    )
+
+    campaign_id = str(uuid.uuid4())
+    campaign = _Campaign(
+        id=campaign_id,
+        account_hash=account_hash,
+        symbol=symbol,
+        instruction=instr,
+        quantity=quantity,
+        chunks=chunks_resolved,
+        range_start=float(range_start),
+        range_end=float(range_end),
+        step=float(step if step is not None else _DEFAULT_STEP),
+        pattern=pattern_resolved,
+        step_interval_seconds=float(
+            step_interval_seconds
+            if step_interval_seconds is not None
+            else _DEFAULT_INTERVAL_SEC
+        ),
+        timing_jitter_pct=float(
+            timing_jitter_pct if timing_jitter_pct is not None else _DEFAULT_JITTER_PCT
+        ),
+        session=session or "NORMAL",
+        duration=duration or "DAY",
+        started_at=datetime.now(timezone.utc),
+        status=STATUS_RUNNING,
+    )
+
+    async with _CAMPAIGNS_LOCK:
+        _CAMPAIGNS[campaign_id] = campaign
+
+    client = ctx.client
+    task = asyncio.create_task(
+        _run_campaign(client, campaign), name=f"fishing-{campaign_id}"
+    )
+    campaign.task = task
+
+    return {
+        "campaign_id": campaign_id,
+        "status": campaign.status,
+        "chunks": list(chunks_resolved),
+        "range_start": float(range_start),
+        "range_end": float(range_end),
+        "step": float(step if step is not None else _DEFAULT_STEP),
+        "pattern": pattern_resolved,
+        "step_interval_seconds": float(
+            step_interval_seconds
+            if step_interval_seconds is not None
+            else _DEFAULT_INTERVAL_SEC
+        ),
+        "timing_jitter_pct": float(
+            timing_jitter_pct if timing_jitter_pct is not None else _DEFAULT_JITTER_PCT
+        ),
+        "started_at": campaign.started_at.isoformat(),
+    }
+
+
+async def get_fishing_status(
+    ctx: SchwabContext,
+    campaign_id: Annotated[
+        str, "Fishing campaign id returned by place_option_order_with_fishing"
+    ],
+) -> JSONType:
+    """
+    Returns the current status of a fishing campaign (chunk-level prices, statuses, fill counts).
+    """
+    _ = ctx  # unused but required for tool signature
+    campaign = _CAMPAIGNS.get(campaign_id)
+    if campaign is None:
+        raise ValueError(f"Unknown campaign_id: {campaign_id}")
+    return campaign.to_status_dict()
+
+
+async def cancel_fishing(
+    ctx: SchwabContext,
+    campaign_id: Annotated[str, "Fishing campaign id to terminate"],
+) -> JSONType:
+    """
+    Terminates a running fishing campaign: cancels the background task, then
+    cancels any sub-orders still working. Returns the final campaign state.
+    *Write operation.*
+    """
+    campaign = _CAMPAIGNS.get(campaign_id)
+    if campaign is None:
+        raise ValueError(f"Unknown campaign_id: {campaign_id}")
+
+    task = campaign.task
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=_CANCEL_GRACE_SECONDS)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            pass
+        except Exception:
+            logger.exception("Fishing %s: task error during cancel", campaign_id)
+
+    # Defensive: also cancel any working orders directly.
+    client = ctx.client
+    for sub in campaign.sub_orders:
+        if sub.is_working() and sub.order_id is not None:
+            await _direct_cancel(client, campaign.account_hash, sub.order_id)
+            sub.schwab_status = "CANCELED"
+            sub.history.append({"at": _now_iso(), "event": "canceled_by_user"})
+
+    if campaign.status == STATUS_RUNNING:
+        campaign.status = STATUS_CANCELED
+        campaign.last_event = "canceled by user via cancel_fishing"
+    return campaign.to_status_dict()
+
+
+# ===== Registration =====
+
+_READ_ONLY_TOOLS = (get_fishing_status,)
+_WRITE_TOOLS = (place_option_order_with_fishing, cancel_fishing)
+
+
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
+    for func in _READ_ONLY_TOOLS:
+        register_tool(server, func, result_transform=result_transform)
+    if not allow_write:
+        return
+    for func in _WRITE_TOOLS:
+        register_tool(server, func, write=True, result_transform=result_transform)
+
+
+__all__ = [
+    "register",
+    "place_option_order_with_fishing",
+    "get_fishing_status",
+    "cancel_fishing",
+    "PATTERN_LINEAR",
+    "PATTERN_RANDOM_WALK",
+    "PATTERN_STAGGERED",
+    "STATUS_RUNNING",
+    "STATUS_FILLED",
+    "STATUS_CANCELED",
+    "STATUS_FAILED",
+    "STATUS_EXHAUSTED",
+]

--- a/tests/test_fishing.py
+++ b/tests/test_fishing.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Any, cast
+
+import pytest
+
+from schwab_mcp.tools import fishing
+from schwab_mcp.tools.fishing import (
+    PATTERN_LINEAR,
+    PATTERN_RANDOM_WALK,
+    PATTERN_STAGGERED,
+    STATUS_CANCELED,
+    STATUS_FILLED,
+    STATUS_RUNNING,
+    _auto_chunks,
+    _Campaign,
+    _initial_prices,
+    _jittered_interval,
+    _next_price,
+    _select_subs_to_adjust,
+    _SubOrder,
+    _validate_inputs,
+)
+
+from conftest import make_ctx, run
+
+
+# ===== Input validation =====
+
+
+class TestValidateInputs:
+    def _ok_args(self, **overrides) -> dict[str, Any]:
+        base = dict(
+            instruction="SELL_TO_OPEN",
+            quantity=8,
+            range_start=9.0,
+            range_end=8.4,
+            step=0.05,
+            pattern="random_walk",
+            chunks=None,
+            step_interval_seconds=300.0,
+            timing_jitter_pct=0.4,
+        )
+        base.update(overrides)
+        return base
+
+    def test_basic_sell_passes(self):
+        instr, chunks, pattern = _validate_inputs(**self._ok_args())
+        assert instr == "SELL_TO_OPEN"
+        assert sum(chunks) == 8
+        assert pattern == "random_walk"
+
+    def test_basic_buy_passes(self):
+        instr, chunks, pattern = _validate_inputs(
+            **self._ok_args(instruction="BUY_TO_CLOSE", range_start=8.4, range_end=9.0)
+        )
+        assert instr == "BUY_TO_CLOSE"
+        assert sum(chunks) == 8
+
+    def test_invalid_instruction(self):
+        with pytest.raises(ValueError, match="instruction must be"):
+            _validate_inputs(**self._ok_args(instruction="HODL"))
+
+    def test_sell_wrong_direction_rejected(self):
+        with pytest.raises(ValueError, match="SELL: range_start"):
+            _validate_inputs(**self._ok_args(range_start=8.4, range_end=9.0))
+
+    def test_buy_wrong_direction_rejected(self):
+        with pytest.raises(ValueError, match="BUY: range_start"):
+            _validate_inputs(
+                **self._ok_args(
+                    instruction="BUY_TO_OPEN", range_start=9.0, range_end=8.4
+                )
+            )
+
+    def test_zero_quantity_rejected(self):
+        with pytest.raises(ValueError, match="quantity must be > 0"):
+            _validate_inputs(**self._ok_args(quantity=0))
+
+    def test_zero_step_rejected(self):
+        with pytest.raises(ValueError, match="step must be > 0"):
+            _validate_inputs(**self._ok_args(step=0))
+
+    def test_step_larger_than_range_rejected(self):
+        with pytest.raises(ValueError, match="range span"):
+            _validate_inputs(**self._ok_args(step=1.0))
+
+    def test_unknown_pattern_rejected(self):
+        with pytest.raises(ValueError, match="pattern must be"):
+            _validate_inputs(**self._ok_args(pattern="lightning"))
+
+    def test_low_interval_rejected(self):
+        with pytest.raises(ValueError, match="step_interval_seconds"):
+            _validate_inputs(**self._ok_args(step_interval_seconds=10))
+
+    def test_jitter_out_of_range(self):
+        with pytest.raises(ValueError, match="timing_jitter_pct"):
+            _validate_inputs(**self._ok_args(timing_jitter_pct=1.5))
+
+    def test_chunks_sum_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="sum.chunks.=7"):
+            _validate_inputs(**self._ok_args(chunks=[3, 2, 2]))
+
+    def test_chunks_with_zero_rejected(self):
+        with pytest.raises(ValueError, match="each chunk must be"):
+            _validate_inputs(**self._ok_args(chunks=[5, 0, 3]))
+
+    def test_chunks_explicit_passes(self):
+        _, chunks, _ = _validate_inputs(**self._ok_args(chunks=[3, 2, 2, 1]))
+        assert chunks == [3, 2, 2, 1]
+
+
+class TestAutoChunks:
+    def test_small_quantity(self):
+        assert _auto_chunks(1) == [1]
+        assert _auto_chunks(2) == [1, 1]
+
+    def test_medium_quantity(self):
+        chunks = _auto_chunks(8)
+        assert sum(chunks) == 8
+        assert 2 <= len(chunks) <= 4
+
+    def test_large_quantity(self):
+        chunks = _auto_chunks(50)
+        assert sum(chunks) == 50
+        assert 2 <= len(chunks) <= 4
+
+
+# ===== Pattern logic =====
+
+
+def _make_campaign(
+    *,
+    instruction: str = "SELL_TO_OPEN",
+    range_start: float = 9.0,
+    range_end: float = 8.4,
+    step: float = 0.05,
+    pattern: str = PATTERN_LINEAR,
+    chunks: list[int] | None = None,
+    timing_jitter_pct: float = 0.0,
+    rng_seed: int = 42,
+) -> _Campaign:
+    chunks = chunks or [3, 2, 2, 1]
+    return _Campaign(
+        id="test-campaign",
+        account_hash="0123456789ABCDEFsuffix1234",
+        symbol="COIN  260717C00250000",
+        instruction=instruction,
+        quantity=sum(chunks),
+        chunks=chunks,
+        range_start=range_start,
+        range_end=range_end,
+        step=step,
+        pattern=pattern,
+        step_interval_seconds=300.0,
+        timing_jitter_pct=timing_jitter_pct,
+        session="NORMAL",
+        duration="DAY",
+        started_at=__import__("datetime").datetime.now(
+            __import__("datetime").timezone.utc
+        ),
+        status=STATUS_RUNNING,
+        rng=random.Random(rng_seed),
+    )
+
+
+class TestInitialPrices:
+    def test_linear_all_same(self):
+        c = _make_campaign(pattern=PATTERN_LINEAR)
+        prices = _initial_prices(c)
+        assert prices == [9.0, 9.0, 9.0, 9.0]
+
+    def test_staggered_descends_for_sell(self):
+        c = _make_campaign(pattern=PATTERN_STAGGERED)
+        prices = _initial_prices(c)
+        # Each later chunk should be ≤ earlier chunk for SELL
+        for i in range(len(prices) - 1):
+            assert prices[i] >= prices[i + 1]
+        # First chunk at range_start
+        assert prices[0] == pytest.approx(9.0)
+        # Stays within range
+        for p in prices:
+            assert c.range_end <= p <= c.range_start
+
+    def test_staggered_ascends_for_buy(self):
+        c = _make_campaign(
+            instruction="BUY_TO_CLOSE",
+            range_start=8.4,
+            range_end=9.0,
+            pattern=PATTERN_STAGGERED,
+        )
+        prices = _initial_prices(c)
+        for i in range(len(prices) - 1):
+            assert prices[i] <= prices[i + 1]
+        assert prices[0] == pytest.approx(8.4)
+        for p in prices:
+            assert 8.4 <= p <= 9.0
+
+    def test_random_walk_within_range(self):
+        c = _make_campaign(pattern=PATTERN_RANDOM_WALK, rng_seed=123)
+        prices = _initial_prices(c)
+        for p in prices:
+            assert c.range_end <= p <= c.range_start
+
+
+class TestNextPrice:
+    def test_linear_sell_steps_down(self):
+        c = _make_campaign(pattern=PATTERN_LINEAR)
+        sub = _SubOrder(chunk_idx=0, quantity=1, price=9.0)
+        nxt = _next_price(c, sub)
+        assert nxt == pytest.approx(8.95)
+
+    def test_linear_buy_steps_up(self):
+        c = _make_campaign(
+            instruction="BUY_TO_OPEN",
+            range_start=8.4,
+            range_end=9.0,
+            pattern=PATTERN_LINEAR,
+        )
+        sub = _SubOrder(chunk_idx=0, quantity=1, price=8.4)
+        nxt = _next_price(c, sub)
+        assert nxt == pytest.approx(8.45)
+
+    def test_sell_clamps_at_floor(self):
+        c = _make_campaign(pattern=PATTERN_LINEAR)
+        sub = _SubOrder(chunk_idx=0, quantity=1, price=8.4)
+        # Already at floor for sell
+        nxt = _next_price(c, sub)
+        assert nxt is None
+
+    def test_buy_clamps_at_ceiling(self):
+        c = _make_campaign(
+            instruction="BUY_TO_OPEN",
+            range_start=8.4,
+            range_end=9.0,
+            pattern=PATTERN_LINEAR,
+        )
+        sub = _SubOrder(chunk_idx=0, quantity=1, price=9.0)
+        nxt = _next_price(c, sub)
+        assert nxt is None
+
+    def test_random_walk_stays_in_range_over_many_iterations(self):
+        c = _make_campaign(pattern=PATTERN_RANDOM_WALK, rng_seed=42)
+        sub = _SubOrder(chunk_idx=0, quantity=1, price=9.0)
+        for _ in range(200):
+            nxt = _next_price(c, sub)
+            if nxt is None:
+                break
+            assert (
+                c.range_end <= nxt <= c.range_start + c.step
+            )  # head-fake permits slight overshoot
+            sub.price = nxt
+        # Eventually should reach the floor under steady downward bias
+        # (200 iterations is plenty)
+        assert sub.price <= c.range_start
+
+    def test_random_walk_eventually_progresses_toward_end(self):
+        c = _make_campaign(pattern=PATTERN_RANDOM_WALK, rng_seed=1)
+        sub = _SubOrder(chunk_idx=0, quantity=1, price=9.0)
+        # Bias is 75% toward end; after many iterations, price should approach range_end
+        for _ in range(500):
+            nxt = _next_price(c, sub)
+            if nxt is None:
+                break
+            sub.price = nxt
+        # We should have moved at least halfway toward the end
+        assert sub.price < 9.0 - (9.0 - 8.4) / 2
+
+
+class TestSelectSubs:
+    def test_linear_selects_all_live(self):
+        c = _make_campaign(pattern=PATTERN_LINEAR)
+        c.sub_orders = [
+            _SubOrder(chunk_idx=0, quantity=2, price=9.0, schwab_status="WORKING"),
+            _SubOrder(chunk_idx=1, quantity=2, price=9.0, schwab_status="FILLED"),
+            _SubOrder(chunk_idx=2, quantity=2, price=9.0, schwab_status="WORKING"),
+        ]
+        selected = _select_subs_to_adjust(c)
+        assert len(selected) == 2
+        assert all(s.schwab_status == "WORKING" for s in selected)
+
+    def test_random_walk_picks_subset(self):
+        c = _make_campaign(pattern=PATTERN_RANDOM_WALK, rng_seed=99)
+        c.sub_orders = [
+            _SubOrder(chunk_idx=i, quantity=1, price=9.0, schwab_status="WORKING")
+            for i in range(5)
+        ]
+        selected = _select_subs_to_adjust(c)
+        assert 1 <= len(selected) <= 2
+
+    def test_no_live_subs(self):
+        c = _make_campaign(pattern=PATTERN_RANDOM_WALK)
+        c.sub_orders = [
+            _SubOrder(chunk_idx=0, quantity=1, price=9.0, schwab_status="FILLED"),
+        ]
+        assert _select_subs_to_adjust(c) == []
+
+
+class TestJitteredInterval:
+    def test_zero_jitter_returns_base(self):
+        c = _make_campaign(timing_jitter_pct=0.0)
+        c.step_interval_seconds = 300.0
+        assert _jittered_interval(c) == 300.0
+
+    def test_jitter_within_bounds(self):
+        c = _make_campaign(timing_jitter_pct=0.5, rng_seed=7)
+        c.step_interval_seconds = 200.0
+        for _ in range(100):
+            v = _jittered_interval(c)
+            # Allow for floor enforcement
+            assert v >= 30.0
+            assert v <= 200.0 * 1.5 + 0.01
+
+
+# ===== Integration tests (with mock schwab client) =====
+
+
+class _FakeOrdersClient:
+    """Minimal fake of the schwab orders client.
+
+    Tracks placed orders + cancel calls and lets tests control returned
+    statuses. Does not use real HTTP — just records and returns.
+    """
+
+    def __init__(self) -> None:
+        self.placed: list[dict[str, Any]] = []
+        self.canceled: list[str] = []
+        self.statuses: dict[str, dict[str, Any]] = {}
+        self._next_id = 1000
+
+    async def place_order(self, account_hash: str, order_spec: dict[str, Any]):
+        oid = str(self._next_id)
+        self._next_id += 1
+        self.placed.append(
+            {"order_id": oid, "account_hash": account_hash, "spec": order_spec}
+        )
+        self.statuses[oid] = {"orderId": oid, "status": "WORKING", "filledQuantity": 0}
+
+        # Build a fake response that the response_handler can parse.
+        class _Resp:
+            def __init__(self, oid, ah):
+                self.status_code = 201
+                self.url = f"https://api.schwabapi.com/trader/v1/accounts/{ah}/orders"
+                self.text = ""
+                self.content = b""
+                self.headers = {
+                    "Location": f"https://api.schwabapi.com/trader/v1/accounts/{ah}/orders/{oid}"
+                }
+                self.is_error = False
+
+            def raise_for_status(self):
+                return None
+
+        return _Resp(oid, account_hash)
+
+    async def cancel_order(self, order_id: str, account_hash: str):
+        self.canceled.append(order_id)
+        if order_id in self.statuses:
+            self.statuses[order_id]["status"] = "CANCELED"
+
+    async def get_order(self, order_id: str, account_hash: str):
+        return self.statuses.get(
+            order_id, {"orderId": order_id, "status": "UNKNOWN", "filledQuantity": 0}
+        )
+
+
+def _patch_call_to_passthrough(monkeypatch):
+    """Replace fishing.call() so the response_handler from orders.py is bypassed
+    and our fake _FakeOrdersClient methods return values directly."""
+
+    async def passthrough(func, *args, **kwargs):
+        rh = kwargs.pop("response_handler", None)
+        result = await func(*args, **kwargs)
+        if rh is not None:
+            # Our fake place_order returns a fake response; let the handler parse it
+            ok, payload = rh(result)
+            return payload if ok else None
+        return result
+
+    monkeypatch.setattr(fishing, "call", passthrough)
+
+
+class TestIntegration:
+    """Integration tests that exercise the campaign tools end-to-end (with mocked schwab client)."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self):
+        fishing._CAMPAIGNS.clear()
+        yield
+        fishing._CAMPAIGNS.clear()
+
+    def test_validation_failure_raises(self, monkeypatch):
+        _patch_call_to_passthrough(monkeypatch)
+        client = _FakeOrdersClient()
+        ctx = make_ctx(client)
+
+        with pytest.raises(ValueError, match="SELL: range_start"):
+            run(
+                fishing.place_option_order_with_fishing(
+                    ctx,
+                    account_hash="abcd1234",
+                    symbol="COIN  260717C00250000",
+                    quantity=8,
+                    instruction="SELL_TO_OPEN",
+                    range_start=8.4,  # wrong direction for SELL
+                    range_end=9.0,
+                )
+            )
+
+    def test_place_and_cancel_immediately(self, monkeypatch):
+        """Submit a campaign, immediately cancel it; should clean up gracefully."""
+        _patch_call_to_passthrough(monkeypatch)
+        # Make the step_interval very long so the bg loop is in its initial sleep
+        # by the time we cancel.
+        client = _FakeOrdersClient()
+        ctx = make_ctx(client)
+
+        async def run_test():
+            result = await fishing.place_option_order_with_fishing(
+                ctx,
+                account_hash="0123456789ABCDEFsuffix1234",
+                symbol="COIN  260717C00250000",
+                quantity=4,
+                instruction="SELL_TO_OPEN",
+                range_start=9.0,
+                range_end=8.4,
+                step=0.05,
+                pattern="linear",
+                chunks=[2, 2],
+                step_interval_seconds=3600.0,  # 1 hour; cancel before tick
+                timing_jitter_pct=0.0,
+            )
+            cid = cast(dict[str, Any], result)["campaign_id"]
+
+            # Wait a tick for the initial placement to complete
+            await asyncio.sleep(0.05)
+
+            # Verify two initial orders placed
+            assert len(client.placed) == 2
+
+            # Cancel
+            final = await fishing.cancel_fishing(ctx, cid)
+            assert cast(dict[str, Any], final)["status"] == STATUS_CANCELED
+            # Both initial orders should be in canceled list
+            assert len(client.canceled) == 2
+
+        asyncio.run(run_test())
+
+    def test_get_status_returns_campaign_state(self, monkeypatch):
+        _patch_call_to_passthrough(monkeypatch)
+        client = _FakeOrdersClient()
+        ctx = make_ctx(client)
+
+        async def run_test():
+            result = await fishing.place_option_order_with_fishing(
+                ctx,
+                account_hash="0123456789ABCDEFsuffix1234",
+                symbol="COIN  260717C00250000",
+                quantity=3,
+                instruction="SELL_TO_OPEN",
+                range_start=9.0,
+                range_end=8.4,
+                step_interval_seconds=3600.0,
+                chunks=[1, 1, 1],
+                pattern="linear",
+            )
+            cid = cast(dict[str, Any], result)["campaign_id"]
+            await asyncio.sleep(0.05)
+
+            status = await fishing.get_fishing_status(ctx, cid)
+            assert cast(dict[str, Any], status)["status"] == STATUS_RUNNING
+            assert cast(dict[str, Any], status)["quantity"] == 3
+            assert len(cast(dict[str, Any], status)["sub_orders"]) == 3
+            assert cast(dict[str, Any], status)["symbol"] == "COIN  260717C00250000"
+
+            # Cleanup
+            await fishing.cancel_fishing(ctx, cid)
+
+        asyncio.run(run_test())
+
+    def test_status_for_unknown_campaign_raises(self, monkeypatch):
+        _patch_call_to_passthrough(monkeypatch)
+        ctx = make_ctx(_FakeOrdersClient())
+        with pytest.raises(ValueError, match="Unknown campaign_id"):
+            run(fishing.get_fishing_status(ctx, "nonexistent"))
+
+    def test_terminal_filled_detected(self, monkeypatch):
+        """Mark every placed order as immediately filled; the loop should detect terminal."""
+        _patch_call_to_passthrough(monkeypatch)
+        client = _FakeOrdersClient()
+        ctx = make_ctx(client)
+
+        # Wrap place_order so each placement is recorded as FILLED before the
+        # next poll cycle sees it. This avoids a race where the loop keeps
+        # canceling and replacing faster than the test can mark a specific
+        # order id.
+        original_place = client.place_order
+
+        async def auto_fill_place(account_hash, order_spec):
+            response = await original_place(account_hash, order_spec)
+            latest_oid = client.placed[-1]["order_id"]
+            # qty is in order_spec under orderLegCollection but easier to peek via spec
+            qty = 0
+            for leg in (order_spec or {}).get("orderLegCollection", []) or []:
+                qty = max(qty, int(leg.get("quantity", 0) or 0))
+            client.statuses[latest_oid] = {
+                "orderId": latest_oid,
+                "status": "FILLED",
+                "filledQuantity": qty or 1,
+            }
+            return response
+
+        client.place_order = auto_fill_place  # type: ignore[assignment]
+
+        original_sleep = asyncio.sleep
+
+        async def fast_sleep(secs):
+            await original_sleep(0.01)
+
+        monkeypatch.setattr(fishing.asyncio, "sleep", fast_sleep)
+
+        async def run_test():
+            result = await fishing.place_option_order_with_fishing(
+                ctx,
+                account_hash="0123456789ABCDEFsuffix1234",
+                symbol="COIN  260717C00250000",
+                quantity=2,
+                instruction="SELL_TO_OPEN",
+                range_start=9.0,
+                range_end=8.4,
+                step=0.05,
+                pattern="linear",
+                chunks=[2],
+                step_interval_seconds=30.0,
+                timing_jitter_pct=0.0,
+            )
+            cid = cast(dict[str, Any], result)["campaign_id"]
+
+            # Wait for loop to detect terminal
+            for _ in range(50):
+                await original_sleep(0.05)
+                if fishing._CAMPAIGNS[cid].status == STATUS_FILLED:
+                    break
+
+            final = fishing._CAMPAIGNS[cid].to_status_dict()
+            assert cast(dict[str, Any], final)["status"] == STATUS_FILLED
+            assert cast(dict[str, Any], final)["filled_quantity_total"] == 2
+
+        asyncio.run(run_test())
+
+
+# ===== Signal renderer integration =====
+
+
+class TestSignalRenderer:
+    def test_place_option_order_with_fishing_rendered(self):
+        from schwab_mcp.approvals.signal import _TOOL_RENDERERS
+
+        renderer = _TOOL_RENDERERS["place_option_order_with_fishing"]
+        msg = renderer(
+            {
+                "account_hash": "…213E",
+                "symbol": "COIN  260717C00250000",
+                "quantity": 8,
+                "instruction": "SELL_TO_OPEN",
+                "range_start": 9.0,
+                "range_end": 8.4,
+                "step": 0.05,
+                "pattern": "random_walk",
+                "chunks": [3, 2, 2, 1],
+                "step_interval_seconds": 300,
+                "timing_jitter_pct": 0.4,
+            },
+            {"213E": "Unmanaged Trust"},
+        )
+        assert "sell to open" in msg
+        assert "8" in msg
+        assert "COIN" in msg
+        assert "07/17/2026" in msg
+        assert "$250" in msg
+        assert "Call" in msg
+        assert "Unmanaged Trust" in msg
+        assert "fishing" in msg.lower()
+        assert "random_walk" in msg
+        assert "3/2/2/1" in msg
+
+    def test_cancel_fishing_rendered(self):
+        from schwab_mcp.approvals.signal import _TOOL_RENDERERS
+
+        renderer = _TOOL_RENDERERS["cancel_fishing"]
+        msg = renderer({"campaign_id": "abc-123"}, {})
+        assert "abc-123" in msg
+        assert "cancel" in msg.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P14D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
## Summary

- New tool **`place_option_order_with_fishing`** — one Signal/Discord approval covers a full multi-iteration option-order campaign across a user-specified price range. Background asyncio task in the MCP server's event loop walks limits from `range_start` toward `range_end`, cancel/replacing as it goes, until filled, exhausted, or a 4-hour cap.
- Companion tools **`get_fishing_status`** (read-only) and **`cancel_fishing`** (write, single approval to terminate).
- **Three step patterns**: `linear` (all chunks together), `staggered` (initial ladder), and `random_walk` (default — biased random walk with head-fakes, only 1-2 chunks adjusted per tick, designed to defeat naive single-trader pattern detection).
- **Order fragmentation**: total quantity auto-splits into 2-4 chunks (or user-supplied list); each chunk is an independent Schwab sub-order.
- **Variable timing**: `step_interval_seconds` (default 300, min 30) with `timing_jitter_pct` (default 0.4 = ±40%).
- Extends Signal approval renderers to also nicely format `place_option_order` (parses OCC symbol → "8 COIN 07/17/2026 \$250 Call contracts") and the new fishing tools' campaign descriptors.

## Why

Doing manual cancel + replace on every iteration during a fishing flow burns two Signal approvals per step. For a normal ~6-step fishing campaign that's 12 approvals, which is friction the user shouldn't have to absorb. With this PR, the user approves the campaign once (with the full range, step, pattern, and timing parameters visible in the Signal message) and the loop runs autonomously inside the MCP server.

The non-linear patterns + chunking also serve a real market-microstructure purpose: at meaningful size in less-liquid options, a metronomic monotonic ladder is detectable by HFT pattern recognition.

## Implementation notes

- Child operations (the per-tick cancel + place) use the schwab client directly via `ctx.client`, bypassing the per-tool approval wrapper. This is the only sane way to honor "one approval per campaign."
- Campaign state lives in an in-memory `_CAMPAIGNS: dict[str, _Campaign]` keyed by UUID. **No persistence** — campaigns die with the server. `cancel_fishing` does a best-effort cleanup of any open sub-orders.
- Hard cap of 4 hours per campaign to bound runaway behavior.
- Direction validation: SELL requires `range_start > range_end`; BUY requires `range_start < range_end`.

## Test plan

- [x] `_validate_inputs` — direction, quantity, step, pattern, interval, jitter, chunks
- [x] `_auto_chunks` — small/medium/large quantities
- [x] `_initial_prices` — linear, staggered (sell + buy), random_walk
- [x] `_next_price` — linear sell/buy, clamping at floor/ceiling, random_walk progression
- [x] `_select_subs_to_adjust` — linear vs random_walk selection
- [x] `_jittered_interval` — zero jitter passthrough, bounded with jitter
- [x] Integration through mocked schwab client: place + cancel, status query, terminal-fill detection
- [x] Signal renderers for `place_option_order_with_fishing` + `cancel_fishing`

**393 tests passing** (354 existing + 39 new). Ruff + Ruff Format + Pyright all clean.

## Notes for review

- The MCP context (`ctx.client`) is captured into the bg task at campaign-start time and used for the lifetime of the campaign. Existing `SchwabContext` lifecycle assumptions hold for the duration of a single MCP server process — which is the intended lifetime of a campaign.
- I intentionally kept campaigns ephemeral. A persistent fishing layer is more code surface (recovery semantics, distributed cancellation, etc.) and the simpler model fits the "one-trader, single-session" use case. Happy to revisit if you want durability.
- `random_walk`'s head-fake probability is small (5%) but real — biased random steps with the occasional move *back toward range_start* defeat the simplest "monotonic ladder" detection without sacrificing average progression toward `range_end`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)