### PR TITLE
Reject mutual fund and other unsupported assetType symbols upfront (closes #29)

### DIFF
--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -69,6 +69,79 @@ _EQUITY_INSTRUCTIONS = frozenset({"BUY", "SELL"})
 _TRAILING_STOP_LINK_TYPES = frozenset({"VALUE", "PERCENT"})
 
 
+class UnsupportedAssetTypeError(ValueError):
+    """Raised when a place_*_order tool is invoked with a symbol whose assetType is not supported by Schwab's order endpoint.
+
+    Schwab's /trader/v1/.../orders endpoint accepts only EQUITY and OPTION as
+    assetType values on the order leg instrument (verified empirically against
+    the live API on 2026-05-27, see issue #29). Sending an equity-shaped payload
+    for a non-equity symbol (e.g. a mutual fund) returns a generic 500 from the
+    upstream API. This pre-check turns that into a clear, actionable error
+    surfaced at the MCP boundary.
+    """
+
+    def __init__(
+        self, *, symbol: str, resolved_type: str, supported: tuple[str, ...]
+    ) -> None:
+        if resolved_type == "MUTUAL_FUND":
+            hint = " For mutual fund orders, use Schwab.com Trade > Mutual Funds."
+        elif resolved_type == "FIXED_INCOME":
+            hint = " For fixed income orders, use Schwab.com Trade > Bonds."
+        else:
+            hint = ""
+        super().__init__(
+            f"Schwab's Trader API does not support {resolved_type} orders on this"
+            f" endpoint. The symbol {symbol!r} resolves to assetType"
+            f" {resolved_type}, but this tool only supports"
+            f" {', '.join(supported)}.{hint}"
+        )
+        self.symbol = symbol
+        self.resolved_type = resolved_type
+        self.supported = supported
+
+
+async def _resolve_symbol_asset_type(client: Any, symbol: str) -> str | None:
+    """Look up a symbol's assetType via the Schwab instruments endpoint.
+
+    Returns None if the lookup fails for any reason (network error, unknown
+    symbol, malformed response), so the caller falls back to letting the
+    upstream API validate. This intentionally avoids adding new failure modes
+    to the order path; if pre-validation cannot answer cleanly, the order
+    proceeds and the existing error-handling path takes over.
+    """
+    try:
+        response = await client.get_instruments(symbol, "symbol-search")
+        response.raise_for_status()
+        data = response.json()
+    except Exception:  # noqa: BLE001 - graceful degradation by design
+        return None
+    instruments = data.get("instruments") if isinstance(data, dict) else None
+    if not instruments or not isinstance(instruments, list):
+        return None
+    first = instruments[0]
+    if not isinstance(first, dict):
+        return None
+    asset_type = first.get("assetType")
+    return asset_type if isinstance(asset_type, str) else None
+
+
+async def _require_supported_asset_type(
+    client: Any, symbol: str, supported: tuple[str, ...]
+) -> None:
+    """Reject an order upfront if the symbol resolves to an unsupported assetType.
+
+    If the lookup cannot determine the assetType, the check passes silently and
+    the upstream API will validate. Only raises when the lookup succeeds AND
+    the resolved type is not in the supported set.
+    """
+    resolved = await _resolve_symbol_asset_type(client, symbol)
+    if resolved is None or resolved in supported:
+        return
+    raise UnsupportedAssetTypeError(
+        symbol=symbol, resolved_type=resolved, supported=supported
+    )
+
+
 def _build_equity_order_spec(
     symbol: str,
     quantity: int,
@@ -330,6 +403,11 @@ async def place_equity_order(
     # Build the core order specification builder
     client = ctx.orders
 
+    # Reject mutual fund (and other unsupported) symbols upfront. Schwab's
+    # /orders endpoint only accepts EQUITY and OPTION assetType values; sending
+    # an equity-shaped payload for a non-equity symbol returns a generic 500.
+    await _require_supported_asset_type(ctx.tools, symbol, supported=("EQUITY",))
+
     order_spec_builder = _build_equity_order_spec(
         symbol, quantity, instruction, order_type, price, stop_price
     )
@@ -428,6 +506,9 @@ async def place_equity_trailing_stop_order(
     *Write operation.*
     """
     client = ctx.orders
+
+    # See place_equity_order: reject unsupported assetType symbols upfront.
+    await _require_supported_asset_type(ctx.tools, symbol, supported=("EQUITY",))
 
     order_spec_builder = _build_trailing_stop_order_spec(
         symbol,

--- a/src/schwab_mcp/tools/utils.py
+++ b/src/schwab_mcp/tools/utils.py
@@ -21,10 +21,16 @@ class SchwabAPIError(Exception):
         status_code: int,
         url: str,
         body: str,
+        correlation_id: str | None = None,
     ) -> None:
+        suffix = f"; correlid={correlation_id}" if correlation_id else ""
         super().__init__(
-            f"Schwab API request failed; status={status_code}; url={url}; body={body}"
+            f"Schwab API request failed; status={status_code}; url={url}; body={body}{suffix}"
         )
+        self.status_code = status_code
+        self.url = url
+        self.body = body
+        self.correlation_id = correlation_id
 
 
 def parse_date(value: str | datetime.date | None) -> datetime.date | None:
@@ -83,10 +89,15 @@ async def call(
                 if raw
                 else f"HTTP {response.status_code}"
             )
+        headers = getattr(response, "headers", None)
+        correlation_id = (
+            headers.get("Schwab-Client-CorrelId") if headers is not None else None
+        )
         raise SchwabAPIError(
             status_code=response.status_code,
             url=response.url,
             body=body,
+            correlation_id=correlation_id,
         ) from exc
 
     if response_handler is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,17 +106,54 @@ def order_response_factory():
     return factory
 
 
+class DummyInstrumentsResponse:
+    """Mock HTTP response for get_instruments lookup.
+
+    Defaults to a single EQUITY-typed instrument so order tests that do not
+    explicitly exercise the asset-type validator continue to pass through.
+    """
+
+    def __init__(self, symbol: str = "TEST", asset_type: str | None = "EQUITY") -> None:
+        self.status_code = 200
+        instruments: list[dict[str, Any]] = []
+        if asset_type is not None:
+            instruments.append({"symbol": symbol, "assetType": asset_type})
+        self._payload = {"instruments": instruments}
+        self.headers: dict[str, str] = {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self._payload
+
+
 class DummyPlaceOrderClient:
-    """Mock client for place_order() method testing."""
+    """Mock client for place_order() method testing.
+
+    Also stubs `get_instruments` so the upfront asset-type validator added by
+    issue #29 returns EQUITY for any looked-up symbol by default. Tests that
+    want to exercise the rejection path can set
+    `client.asset_type_override = "MUTUAL_FUND"` (or any other value), or set
+    `client.asset_type_override = "raise"` to simulate a lookup failure.
+    """
 
     def __init__(self, order_response: Any):
         self.captured: dict[str, Any] | None = None
         self._response = order_response
+        self.asset_type_override: str | None = "EQUITY"
 
     async def place_order(self, *args: Any, **kwargs: Any) -> Any:
         """Capture call arguments and return mock response."""
         self.captured = {"args": args, "kwargs": kwargs}
         return self._response
+
+    async def get_instruments(self, symbol: str, projection: Any) -> Any:  # noqa: ARG002
+        if self.asset_type_override == "raise":
+            raise RuntimeError("simulated get_instruments failure")
+        return DummyInstrumentsResponse(
+            symbol=symbol, asset_type=self.asset_type_override
+        )
 
 
 @pytest.fixture

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -241,6 +241,93 @@ class TestPlaceEquityOrder:
         assert order_spec["session"] == "AM"
         assert order_spec["duration"] == "GOOD_TILL_CANCEL"
 
+    def test_rejects_mutual_fund_symbol_before_placing(
+        self, place_order_client, account_hash
+    ):
+        place_order_client.asset_type_override = "MUTUAL_FUND"
+        ctx = make_ctx(place_order_client)
+
+        with pytest.raises(orders.UnsupportedAssetTypeError) as excinfo:
+            run(
+                orders.place_equity_order(
+                    ctx,
+                    account_hash,
+                    "LENDX",
+                    109,
+                    "sell",
+                    "market",
+                )
+            )
+
+        # No order was placed at the upstream API; the rejection short-circuits.
+        assert place_order_client.captured is None
+        err = excinfo.value
+        assert err.symbol == "LENDX"
+        assert err.resolved_type == "MUTUAL_FUND"
+        assert err.supported == ("EQUITY",)
+        assert "Schwab.com" in str(err)
+
+    def test_rejects_fixed_income_symbol_before_placing(
+        self, place_order_client, account_hash
+    ):
+        place_order_client.asset_type_override = "FIXED_INCOME"
+        ctx = make_ctx(place_order_client)
+
+        with pytest.raises(orders.UnsupportedAssetTypeError):
+            run(
+                orders.place_equity_order(
+                    ctx,
+                    account_hash,
+                    "912828YY0",
+                    1,
+                    "sell",
+                    "market",
+                )
+            )
+        assert place_order_client.captured is None
+
+    def test_passes_through_when_lookup_fails(
+        self, place_order_client, account_hash, order_id
+    ):
+        """Graceful degradation: a lookup error must not block the order."""
+        place_order_client.asset_type_override = "raise"
+        ctx = make_ctx(place_order_client)
+
+        result = run(
+            orders.place_equity_order(
+                ctx,
+                account_hash,
+                "AAPL",
+                100,
+                "buy",
+                "market",
+            )
+        )
+
+        assert result["orderId"] == order_id
+        assert place_order_client.captured is not None
+
+    def test_passes_through_when_lookup_returns_no_instruments(
+        self, place_order_client, account_hash, order_id
+    ):
+        """An empty `instruments` list is also treated as a non-result."""
+        place_order_client.asset_type_override = None
+        ctx = make_ctx(place_order_client)
+
+        result = run(
+            orders.place_equity_order(
+                ctx,
+                account_hash,
+                "AAPL",
+                100,
+                "buy",
+                "market",
+            )
+        )
+
+        assert result["orderId"] == order_id
+        assert place_order_client.captured is not None
+
 
 class TestPlaceOptionOrder:
     @pytest.fixture
@@ -397,6 +484,26 @@ class TestPlaceEquityTrailingStopOrder:
 
         order_spec = place_order_client.captured["kwargs"]["order_spec"]
         assert order_spec["stopPriceLinkType"] == "VALUE"
+
+    def test_rejects_mutual_fund_symbol_before_placing(
+        self, place_order_client, account_hash
+    ):
+        place_order_client.asset_type_override = "MUTUAL_FUND"
+        ctx = make_ctx(place_order_client)
+
+        with pytest.raises(orders.UnsupportedAssetTypeError):
+            run(
+                orders.place_equity_trailing_stop_order(
+                    ctx,
+                    account_hash,
+                    "LENDX",
+                    50,
+                    "SELL",
+                    5.00,
+                )
+            )
+
+        assert place_order_client.captured is None
 
 
 class TestPlaceBracketOrder:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ class MockResponse:
         content: bytes = b"",
         json_data: dict | list | None = None,
         raise_error: bool = False,
+        headers: dict[str, str] | None = None,
     ) -> None:
         self.status_code = status_code
         self.url = url
@@ -22,6 +23,7 @@ class MockResponse:
         self.content = content
         self._json_data = json_data
         self._raise_error = raise_error
+        self.headers = headers if headers is not None else {}
 
     def raise_for_status(self) -> None:
         if self._raise_error:
@@ -121,6 +123,39 @@ class TestSchwabAPIError:
             run(call(fake_endpoint))
 
         assert exc_info.value.__cause__ is not None
+
+    def test_surfaces_schwab_client_correlid_when_present(self):
+        async def fake_endpoint():
+            return MockResponse(
+                status_code=500,
+                url="https://api.schwabapi.com/orders",
+                text='{"message":"upstream boom"}',
+                raise_error=True,
+                headers={"Schwab-Client-CorrelId": "abc-123-def-456"},
+            )
+
+        with pytest.raises(SchwabAPIError) as exc_info:
+            run(call(fake_endpoint))
+
+        error = exc_info.value
+        assert error.correlation_id == "abc-123-def-456"
+        assert "correlid=abc-123-def-456" in str(error)
+
+    def test_correlid_absent_when_header_missing(self):
+        async def fake_endpoint():
+            return MockResponse(
+                status_code=500,
+                url="https://api.schwabapi.com/orders",
+                text="boom",
+                raise_error=True,
+            )
+
+        with pytest.raises(SchwabAPIError) as exc_info:
+            run(call(fake_endpoint))
+
+        error = exc_info.value
+        assert error.correlation_id is None
+        assert "correlid=" not in str(error)
 
 
 class TestResponseHandler:


### PR DESCRIPTION
Closes #29.

## Summary

`place_equity_order` against a mutual fund symbol (e.g. `LENDX`) returned a generic Schwab API 500. The diagnostic logged in issue #29 confirmed that Schwab's `/trader/v1/.../orders` endpoint accepts only `EQUITY` and `OPTION` on the order leg instrument; a correctly-shaped `MUTUAL_FUND` payload gets a clean `400` with `"Valid value for assetType is [EQUITY, OPTION]"`, and the equity-shaped payload for a mutual-fund symbol gets the same internal validation rejection wrapped in a generic 500.

This PR adds an upfront `get_instruments` lookup at the top of `place_equity_order` and `place_equity_trailing_stop_order`. When the resolved `assetType` is set and is not in the tool's supported set, the call short-circuits with `UnsupportedAssetTypeError` and a clear, actionable message that points the user at the right Schwab.com flow (Trade > Mutual Funds for `MUTUAL_FUND`, Trade > Bonds for `FIXED_INCOME`). When the lookup cannot determine the `assetType` (network error, unknown symbol, malformed response), the check passes silently and the upstream API takes over, so this never adds a new failure mode to the order path.

Also surfaces the `Schwab-Client-CorrelId` response header in `SchwabAPIError` so users have an identifier to share when escalating to Schwab support. The body and status code were already surfaced.

## Known limitation

The rejection still fires after the approval gate, so the first attempt against a mutual fund symbol still burns one Signal/Discord approval cycle. The user then gets the clear error instead of the prior generic 500, which is still a big UX win, but it does not match the "save the approval cycle" goal called out in #29. Hoisting the validation in front of the approval wrapper is an architectural change (a pre-approval validator hook on `register_tool`) and is best done in a separate PR.

## Scope

Limited to the two single-leg equity tools for now (`place_equity_order`, `place_equity_trailing_stop_order`). Multi-leg tools (`place_bracket_order`, `place_one_cancels_other_order`, `place_first_triggers_second_order`) and the option-side tools (`place_option_order`, `place_option_combo_order`) can adopt the same pattern in follow-up PRs once this one is proven.

## Test plan

- [x] New tests in `tests/test_orders.py` cover: MF symbol rejected before placing, `FIXED_INCOME` symbol rejected, `get_instruments` lookup failure passes through, empty-instruments response passes through, trailing-stop variant rejects MF too.
- [x] New tests in `tests/test_utils.py` cover: `Schwab-Client-CorrelId` is captured and surfaced when present, and absent when the header is missing.
- [x] Existing `DummyPlaceOrderClient` fixture extended to stub `get_instruments` with a per-instance `asset_type_override`, so all prior order tests continue to pass through the new validator.
- [x] Full pytest suite green (400 tests), ruff + pyright + pre-commit hooks all pass.

## Follow-ups

1. Architectural: hoist the asset-type validator in front of the approval wrapper so MF/FIXED_INCOME attempts do not burn an approval cycle. Likely shape: a `pre_validate` parameter on `register_tool` that the approval wrapper calls before `approvals.require`.
2. Coverage: apply the same upfront check to multi-leg and option order tools.
3. Outreach: confirm with Schwab developer relations whether MF orders are exposed via any Trader API endpoint, or only via the internal endpoints used by Schwab.com. If a separate endpoint exists, schwab-mcp can grow a `place_mutual_fund_order` tool.